### PR TITLE
Set up basic parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ public
 
     _:
       name 'Kevin'
-      age 38
+      age 39
 
 -- For schema and/or table names with whitespace, use double quotes
 "schema name with spaces"

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -241,7 +241,7 @@ r#"public
   person
     kevin
       name 'Kevin'
-      age 38
+      age 39
       favorite_book 'Cat''s Cradle'
 
 "quoted @ schema"
@@ -313,7 +313,7 @@ r#"public
 
             indent("      "),
             T::Identifier("age".to_owned()),
-            T::Number("38".to_owned()),
+            T::Number("39".to_owned()),
             T::Newline,
 
             indent("      "),

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -1,7 +1,6 @@
+mod tokenizer;
 
-mod machine;
-
-use machine::Machine;
+use tokenizer::Tokenizer;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
@@ -16,9 +15,7 @@ pub enum Token {
 }
 
 pub fn lex(text: &str) -> Vec<Token> {
-    let mut machine = Machine::new();
-    machine.lex(text);
-    machine.tokens
+    Tokenizer::new().tokenize(text).tokens
 }
 
 #[cfg(test)]

--- a/src/lex/tokenizer.rs
+++ b/src/lex/tokenizer.rs
@@ -17,13 +17,13 @@ pub enum State {
 }
 
 #[derive(Debug)]
-pub(super) struct Machine {
+pub(super) struct Tokenizer {
     state: State,
     stack: Vec<char>,
     pub tokens: Vec<Token>,
 }
 
-impl Machine {
+impl Tokenizer {
     pub fn new() -> Self {
         Self {
             state: State::LineStart,
@@ -32,7 +32,7 @@ impl Machine {
         }
     }
 
-    pub fn lex(&mut self, input: &str) {
+    pub fn tokenize(mut self, input: &str) -> Self {
         for (line_num, line) in input.lines().enumerate() {
             self.state = State::LineStart;
 
@@ -290,6 +290,8 @@ impl Machine {
 
             self.tokens.push(Token::Newline);
         }
+
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
-mod lexer;
+mod lex;
+mod parse;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -212,6 +212,306 @@ mod tests {
         ]);
     }
 
+    #[test]
+    fn tables_quoted_identifiers() {
+        let tokens = vec![
+            T::QuotedIdentifier("public schema".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::QuotedIdentifier("a table".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::QuotedIdentifier("another table".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public schema".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "a table".to_owned(),
+                        records: Vec::new(),
+                    },
+                    Table {
+                        name: "another table".to_owned(),
+                        records: Vec::new(),
+                    },
+                ],
+            },
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unexpected token")]
+    fn tables_without_newlines() {
+        let tokens = vec![
+            T::Identifier("schema1".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("table1".to_owned()),
+            T::Indent("    ".to_owned()),
+            T::Identifier("table2".to_owned()),
+        ];
+
+        parse(tokens);
+
+        let tokens = vec![
+            T::Identifier("schema1".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("table1".to_owned()),
+            T::Identifier("table2".to_owned()),
+        ];
+
+        parse(tokens);
+
+        let tokens = vec![
+            T::Identifier("schema1".to_owned()),
+            T::Indent("    ".to_owned()),
+            T::Identifier("table1".to_owned()),
+            T::Identifier("table2".to_owned()),
+        ];
+
+        parse(tokens);
+    }
+
+    #[test]
+    fn named_record() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("kevin".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("kevin".to_owned()),
+                                attributes: Vec::new(),
+                            }
+                        ]
+                    }
+                ],
+            },
+        ]);
+    }
+
+    #[test]
+    fn named_records() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("stacey".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("pet".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("eiyre".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("cupid".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("stacey".to_owned()),
+                                attributes: Vec::new(),
+                            },
+                            Record {
+                                name: Some("kevin".to_owned()),
+                                attributes: Vec::new(),
+                            },
+                        ]
+                    },
+                    Table {
+                        name: "pet".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("eiyre".to_owned()),
+                                attributes: Vec::new(),
+                            },
+                            Record {
+                                name: Some("cupid".to_owned()),
+                                attributes: Vec::new(),
+                            },
+                        ]
+                    },
+                ],
+            },
+        ]);
+    }
+
+    #[test]
+    fn anonymous_record() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            }
+                        ]
+                    }
+                ],
+            },
+        ]);
+    }
+
+    #[test]
+    fn anonymous_records() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("pet".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            },
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            },
+                        ]
+                    },
+                    Table {
+                        name: "pet".to_owned(),
+                        records: vec![
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            },
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            },
+                        ]
+                    },
+                ],
+            },
+        ]);
+    }
+
+    #[test]
+    fn mixed_records() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("pet".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Underscore,
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("eiyre".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("kevin".to_owned()),
+                                attributes: Vec::new(),
+                            },
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            },
+                        ]
+                    },
+                    Table {
+                        name: "pet".to_owned(),
+                        records: vec![
+                            Record {
+                                name: None,
+                                attributes: Vec::new(),
+                            },
+                            Record {
+                                name: Some("eiyre".to_owned()),
+                                attributes: Vec::new(),
+                            },
+                        ]
+                    },
+                ],
+            },
+        ]);
+    }
+
     //#[test]
     fn single_record() {
         let tokens = vec![

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,0 +1,257 @@
+
+
+/*
+schema
+  table
+    name1
+      col1 val
+      col2 val
+
+    name2
+      col1 val
+
+    _
+      col1 val
+      col2 val
+      col3 val
+
+
+*/
+mod parser;
+
+use super::lex::Token;
+use parser::Parser;
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    Boolean(bool),
+    Number(String),
+    Text(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Attribute {
+    name: String,
+    value: Value,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Record {
+    name: Option<String>,
+    attributes: Vec<Attribute>,
+}
+
+impl Record {
+    fn new(name: Option<String>) -> Self {
+        Self {
+            name,
+            attributes: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Table {
+    pub name: String,
+    pub records: Vec<Record>,
+}
+
+impl Table {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            records: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Schema {
+    pub name: String,
+    pub tables: Vec<Table>,
+}
+
+impl Schema {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            tables: Vec::new(),
+        }
+    }
+}
+
+pub fn parse(tokens: Vec<Token>) -> Vec<Schema> {
+    Parser::new().parse(tokens).schemas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{*, Token as T};
+
+    #[test]
+    fn empty() {
+        assert_eq!(parse(vec![]), vec![]);
+    }
+
+    #[test]
+    fn schema() {
+        let tokens = vec![
+            T::Newline,
+            T::Identifier("public".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+
+            Schema {
+                name: "public".to_owned(),
+                tables: Vec::new(),
+            },
+        ]);
+    }
+
+    #[test]
+    fn schemas() {
+        let tokens = vec![
+            T::Identifier("schema1".to_owned()),
+            T::Newline,
+            T::Newline,
+            T::Identifier("schema2".to_owned()),
+            T::Newline,
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: Vec::new(),
+            },
+            Schema {
+                name: "schema2".to_owned(),
+                tables: Vec::new(),
+            },
+        ]);
+
+        let tokens = vec![
+            T::Newline,
+            T::Newline,
+            T::Identifier("schema1".to_owned()),
+            T::Newline,
+            T::Identifier("schema2".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: Vec::new(),
+            },
+            Schema {
+                name: "schema2".to_owned(),
+                tables: Vec::new(),
+            },
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unexpected token")]
+    fn schemas_without_newlines() {
+        let tokens = vec![
+            T::Identifier("schema1".to_owned()),
+            T::Identifier("schema2".to_owned()),
+        ];
+
+        parse(tokens);
+    }
+
+    #[test]
+    fn table() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("my_table".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "my_table".to_owned(),
+                        records: Vec::new(),
+                    }
+                ],
+            },
+        ]);
+    }
+
+    #[test]
+    fn tables() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("table1".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("table2".to_owned()),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "table1".to_owned(),
+                        records: Vec::new(),
+                    },
+                    Table {
+                        name: "table2".to_owned(),
+                        records: Vec::new(),
+                    },
+                ],
+            },
+        ]);
+    }
+
+    //#[test]
+    fn single_record() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+
+            T::Indent("  ".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+
+            T::Indent("    ".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+
+            T::Indent("      ".to_owned()),
+            T::Identifier("name".to_owned()),
+            T::Text("Kevin".to_owned()),
+            T::Newline,
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("kevin".to_owned()),
+                                attributes: vec![
+                                    Attribute {
+                                        name: "name".to_owned(),
+                                        value: Value::Text("Kevin".to_owned()),
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]);
+    }
+}

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -512,24 +512,37 @@ mod tests {
         ]);
     }
 
-    //#[test]
-    fn single_record() {
+    #[test]
+    #[should_panic(expected = "Unexpected token")]
+    fn invalid_records() {
+        let tokens = vec![
+            T::Identifier("schema1".to_owned()),
+            T::Newline,
+            T::Indent("  ".to_owned()),
+            T::Identifier("table1".to_owned()),
+            T::Newline,
+            T::Indent("    ".to_owned()),
+            T::Identifier("record1".to_owned()),
+            T::Identifier("another_identifier".to_owned()),
+        ];
+
+        parse(tokens);
+    }
+
+    #[test]
+    fn attribute() {
         let tokens = vec![
             T::Identifier("public".to_owned()),
             T::Newline,
-
-            T::Indent("  ".to_owned()),
+            T::Indent("\t".to_owned()),
             T::Identifier("person".to_owned()),
             T::Newline,
-
-            T::Indent("    ".to_owned()),
+            T::Indent("\t\t".to_owned()),
             T::Identifier("kevin".to_owned()),
             T::Newline,
-
-            T::Indent("      ".to_owned()),
+            T::Indent("\t\t\t".to_owned()),
             T::Identifier("name".to_owned()),
             T::Text("Kevin".to_owned()),
-            T::Newline,
         ];
 
         assert_eq!(parse(tokens), vec![
@@ -553,5 +566,186 @@ mod tests {
                 ]
             }
         ]);
+    }
+
+    #[test]
+    fn lotsa_attributes() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("name".to_owned()),
+            T::Text("Kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("age".to_owned()),
+            T::Number("39".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Underscore,
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("name".to_owned()),
+            T::Text("Nobody".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::QuotedIdentifier("IsIdentifiable?".to_owned()),
+            T::Boolean(false),
+            T::Newline,
+            T::Identifier("private_schema".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("pet".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("cupid".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("loves_belly_scratches".to_owned()),
+            T::Boolean(true),
+        ];
+
+        assert_eq!(parse(tokens), vec![
+            Schema {
+                name: "public".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "person".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("kevin".to_owned()),
+                                attributes: vec![
+                                    Attribute {
+                                        name: "name".to_owned(),
+                                        value: Value::Text("Kevin".to_owned()),
+                                    },
+                                    Attribute {
+                                        name: "age".to_owned(),
+                                        value: Value::Number("39".to_owned()),
+                                    },
+                                ],
+                            },
+                            Record {
+                                name: None,
+                                attributes: vec![
+                                    Attribute {
+                                        name: "name".to_owned(),
+                                        value: Value::Text("Nobody".to_owned()),
+                                    },
+                                    Attribute {
+                                        name: "IsIdentifiable?".to_owned(),
+                                        value: Value::Boolean(false),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            Schema {
+                name: "private_schema".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "pet".to_owned(),
+                        records: vec![
+                            Record {
+                                name: Some("cupid".to_owned()),
+                                attributes: vec![
+                                    Attribute {
+                                        name: "loves_belly_scratches".to_owned(),
+                                        value: Value::Boolean(true),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unexpected token")]
+    fn expecting_attribute_wrong_token() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Boolean(false),
+        ];
+
+        parse(tokens);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected value for attribute")]
+    fn attribute_without_value() {
+        let mut tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("name".to_owned()),
+        ];
+
+        parse(tokens);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected value for attribute")]
+    fn attribute_without_value_newline() {
+        let mut tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("name".to_owned()),
+            T::Newline,
+        ];
+
+        parse(tokens);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unexpected token")]
+    fn attribute_with_extra_identifier() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("name".to_owned()),
+            T::Text("Kevin".to_owned()),
+            T::Identifier("name".to_owned()),
+        ];
+
+        parse(tokens);
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,22 +1,3 @@
-
-
-/*
-schema
-  table
-    name1
-      col1 val
-      col2 val
-
-    name2
-      col1 val
-
-    _
-      col1 val
-      col2 val
-      col3 val
-
-
-*/
 mod parser;
 
 use super::lex::Token;

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -6,6 +6,7 @@ detect indentation level
 
 */
 use super::{
+    Record,
     Schema,
     Table,
     Token,
@@ -18,6 +19,7 @@ pub enum State {
     //ExpectingSchema,
     CreatedSchema,
     CreatedTable,
+    CreatedRecord,
     ExpectingNewline,
     ExpectingTable,
     ExpectingRecord,
@@ -85,7 +87,7 @@ impl Parser {
                     _ => panic!("Unexpected token {:?}", token)
                 }
 
-                CreatedSchema | CreatedTable => match token {
+                CreatedSchema | CreatedTable | CreatedRecord => match token {
                     Token::Newline => {
                         LineStart
                     }
@@ -105,24 +107,30 @@ impl Parser {
                     _ => panic!("Unexpected token {:?}", token)
                 }
 
-                /*
-                ExpectingNewline => match token {
-                    Token::Newline => LineStart,
-                    _ => panic!("Expected newline")
-                }
-
                 ExpectingRecord => match token {
-                    Token::Newline => LineStart,
+                    Token::Newline => {
+                        LineStart
+                    }
                     Token::Identifier(_) | Token::Underscore => {
                         let name = match token {
                             Token::Identifier(ident) => Some(ident),
                             Token::Underscore => None,
                             _ => unreachable!()
                         };
-                        println!("Creating record: {:?}", name);
-                        LineStart
+                        let table = self
+                            .schemas.last_mut().expect("No schema to find table")
+                            .tables.last_mut().expect("No table to add record to");
+                        table.records.push(Record::new(name));
+                        CreatedRecord
                     }
                     _ => panic!("Unexpected token {:?}", token)
+                }
+
+                /*
+
+                ExpectingNewline => match token {
+                    Token::Newline => LineStart,
+                    _ => panic!("Expected newline")
                 }
 
                 ExpectingColumn => match token {
@@ -153,7 +161,7 @@ impl Parser {
                     _ => panic!("Unexpected token {:?}", token)
                 }
                 */
-                _ => panic!()
+                _ => unreachable!()
             }
         }
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1,0 +1,270 @@
+/*
+
+detect indentation level
+
+
+
+*/
+use super::{
+    Schema,
+    Table,
+    Token,
+    Value,
+};
+
+#[derive(Debug, PartialEq)]
+pub enum State {
+    LineStart,
+    //ExpectingSchema,
+    CreatedSchema,
+    CreatedTable,
+    ExpectingNewline,
+    ExpectingTable,
+    ExpectingRecord,
+    ExpectingColumn,
+    ExpectingValue,
+}
+
+#[derive(Debug)]
+pub(super) struct Parser {
+    indent_unit: Option<String>,
+    //current_indent_level: usize,
+    state: State,
+    //stack: Vec<Token>,
+    pub schemas: Vec<Schema>,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Self {
+            indent_unit: None,
+            //current_indent_level: 0,
+            schemas: Vec::new(),
+            state: State::LineStart,
+            //stack: Vec::new(),
+        }
+    }
+
+    pub fn parse(mut self, tokens: Vec<Token>) -> Self {
+        use State::*;
+
+        for token in tokens {
+            self.state = match self.state {
+
+                LineStart => match token {
+                    Token::Newline => {
+                        LineStart
+                    }
+                    Token::Indent(indent) => {
+                        if indent.len() == 0 {
+                            panic!("Empty indent received");
+                        }
+
+                        if indent.trim().len() > 0 {
+                            panic!("Non-whitespace indent received");
+                        }
+
+                        if let None = &self.indent_unit {
+                            self.indent_unit = Some(indent.clone());
+                        }
+
+                        match indent_level(self.indent_unit.as_ref().unwrap(), &indent) {
+                            Some(level) => match level {
+                                1 => ExpectingTable,
+                                2 => ExpectingRecord,
+                                3 => ExpectingColumn,
+                                _ => panic!("Unexpected indentation level")
+                            }
+                            None => panic!("Inconsistent indent")
+                        }
+                    }
+                    Token::Identifier(ident) | Token::QuotedIdentifier(ident) => {
+                        self.schemas.push(Schema::new(ident.clone()));
+                        CreatedSchema
+                    }
+                    _ => panic!("Unexpected token {:?}", token)
+                }
+
+                CreatedSchema | CreatedTable => match token {
+                    Token::Newline => {
+                        LineStart
+                    }
+                    _ => panic!("Unexpected token {:?}", token)
+                }
+
+                ExpectingTable => match token {
+                    Token::Newline => {
+                        LineStart
+                    }
+                    Token::Identifier(ident) | Token::QuotedIdentifier(ident) => {
+                        let schema = self.schemas.last_mut().expect("No schema to add table to");
+                        schema.tables.push(Table::new(ident.clone()));
+                        CreatedTable
+                    }
+
+                    _ => panic!("Unexpected token {:?}", token)
+                }
+
+                /*
+                ExpectingNewline => match token {
+                    Token::Newline => LineStart,
+                    _ => panic!("Expected newline")
+                }
+
+                ExpectingRecord => match token {
+                    Token::Newline => LineStart,
+                    Token::Identifier(_) | Token::Underscore => {
+                        let name = match token {
+                            Token::Identifier(ident) => Some(ident),
+                            Token::Underscore => None,
+                            _ => unreachable!()
+                        };
+                        println!("Creating record: {:?}", name);
+                        LineStart
+                    }
+                    _ => panic!("Unexpected token {:?}", token)
+                }
+
+                ExpectingColumn => match token {
+                    Token::Newline => LineStart,
+                    Token::Identifier(_) | Token::QuotedIdentifier(_) => {
+                        // create new table, yada yada
+                        ExpectingValue
+                    }
+                    _ => panic!("Unexpected token {:?}", token)
+                }
+
+                ExpectingValue => match token {
+                    Token::Boolean(b) => {
+                        let val = Value::Boolean(b);
+                        // create the attribute
+                        ExpectingNewline
+                    }
+                    Token::Number(n) => {
+                        let val = Value::Number(n);
+                        // create the attribute
+                        ExpectingNewline
+                    }
+                    Token::Text(t) => {
+                        let val = Value::Text(t);
+                        // create the attribute
+                        ExpectingNewline
+                    }
+                    _ => panic!("Unexpected token {:?}", token)
+                }
+                */
+                _ => panic!()
+            }
+        }
+
+        self
+    }
+}
+
+fn indent_level(unit: &str, indent: &str) -> Option<usize> {
+    // A valid indent, when split by the indent unit, will yield
+    // a collection of empty strings, with the collection length
+    // being one longer than the "indent level".
+    //
+    // Eg: "    ".split("  ") => ["", "", ""]
+    let parts: Vec<&str> = indent.split(unit).collect();
+
+    for p in &parts {
+        if p.len() > 0 {
+            return None;
+        }
+    }
+
+    Some(parts.len() - 1)
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod indent_level {
+        use super::super::indent_level;
+
+        fn spaces(count: usize) -> String {
+            " ".repeat(count)
+        }
+
+        fn tabs(count: usize) -> String {
+            "\t".repeat(count)
+        }
+
+        #[test]
+        fn valid_indents() {
+            let assert_valid = |unit: &str, indent: &str, expected_level: usize| {
+                assert_eq!(
+                    indent_level(unit, indent),
+                    Some(expected_level),
+                    "unit: {:?}, indent: {:?}, level: {}",
+                    unit,
+                    indent,
+                    expected_level,
+                );
+            };
+
+            // Only explicitly care about expected indentation levels...
+            //
+            //   - schema name: 0
+            //   - table name:  1
+            //   - record name: 2
+            //   - attribute:   3
+            //
+            // ... and indentation levels defined by...
+            //
+            //   - single space
+            //   - double space
+            //   - quadruple space
+            //   - tab
+
+            assert_valid(&spaces(1), &spaces(0), 0);
+            assert_valid(&spaces(1), &spaces(1), 1);
+            assert_valid(&spaces(1), &spaces(2), 2);
+            assert_valid(&spaces(1), &spaces(3), 3);
+
+            assert_valid(&spaces(2), &spaces(0), 0);
+            assert_valid(&spaces(2), &spaces(2), 1);
+            assert_valid(&spaces(2), &spaces(4), 2);
+            assert_valid(&spaces(2), &spaces(6), 3);
+
+            assert_valid(&spaces(4), &spaces(0),  0);
+            assert_valid(&spaces(4), &spaces(4),  1);
+            assert_valid(&spaces(4), &spaces(8),  2);
+            assert_valid(&spaces(4), &spaces(12), 3);
+
+            assert_valid(&tabs(1), &tabs(0), 0);
+            assert_valid(&tabs(1), &tabs(1), 1);
+            assert_valid(&tabs(1), &tabs(2), 2);
+            assert_valid(&tabs(1), &tabs(3), 3);
+        }
+
+        #[test]
+        fn invalid_indents() {
+            let assert_invalid = |unit: &str, indent: &str| {
+                assert_eq!(
+                    indent_level(unit, indent),
+                    None,
+                    "unit: {:?}, indent: {:?}",
+                    unit,
+                    indent,
+                );
+            };
+            assert_invalid(&spaces(2), &spaces(1));
+            assert_invalid(&spaces(2), &spaces(3));
+            assert_invalid(&spaces(2), &spaces(5));
+
+            assert_invalid(&spaces(4), &spaces(1));
+            assert_invalid(&spaces(4), &spaces(2));
+            assert_invalid(&spaces(4), &spaces(3));
+            assert_invalid(&spaces(4), &spaces(5));
+            assert_invalid(&spaces(4), &spaces(6));
+            assert_invalid(&spaces(4), &spaces(7));
+            assert_invalid(&spaces(4), &spaces(9));
+
+            assert_invalid(&spaces(1), &tabs(1));
+            assert_invalid(&tabs(1), &spaces(1));
+        }
+    }
+}


### PR DESCRIPTION
This PR builds on the tokenizer from #1 and parses tokens into basic collections.

It essentially only checks syntax; it does not perform additional validations like making sure record names within a table are unique, column names are unique within a record, etc.