### PR TITLE
Simple validator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-mod lex;
-mod parse;
-mod validate;
+pub mod lex;
+pub mod parse;
+pub mod validate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 mod lex;
 mod parse;
+mod validate;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -12,18 +12,18 @@ pub enum Value {
 
 #[derive(Debug, PartialEq)]
 pub struct Attribute {
-    name: String,
-    value: Value,
+    pub name: String,
+    pub value: Value,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct Record {
-    name: Option<String>,
-    attributes: Vec<Attribute>,
+    pub name: Option<String>,
+    pub attributes: Vec<Attribute>,
 }
 
 impl Record {
-    fn new(name: Option<String>) -> Self {
+    pub fn new(name: Option<String>) -> Self {
         Self {
             name,
             attributes: Vec::new(),
@@ -38,7 +38,7 @@ pub struct Table {
 }
 
 impl Table {
-    fn new(name: String) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             name,
             records: Vec::new(),
@@ -53,7 +53,7 @@ pub struct Schema {
 }
 
 impl Schema {
-    fn new(name: String) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             name,
             tables: Vec::new(),

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -673,7 +673,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Expected value for attribute")]
     fn attribute_without_value() {
-        let mut tokens = vec![
+        let tokens = vec![
             T::Identifier("public".to_owned()),
             T::Newline,
             T::Indent("\t".to_owned()),
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Expected value for attribute")]
     fn attribute_without_value_newline() {
-        let mut tokens = vec![
+        let tokens = vec![
             T::Identifier("public".to_owned()),
             T::Newline,
             T::Indent("\t".to_owned()),

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1,10 +1,3 @@
-/*
-
-detect indentation level
-
-
-
-*/
 use super::{
     Attribute,
     Record,
@@ -153,8 +146,6 @@ impl Parser {
                     }
                     _ => panic!("Expected value for attribute")
                 }
-
-                _ => unreachable!()
             }
         }
 

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -1,0 +1,232 @@
+use super::parse::*;
+
+pub fn validate(schemas: Vec<Schema>) -> Vec<Schema> {
+    let mut validated: Vec<Schema> = Vec::new();
+
+    for schema in schemas {
+        let validated_schema = match validated.iter_mut().find(|v| v.name == schema.name) {
+            Some(v) => v,
+            None => {
+                validated.push(Schema::new(schema.name));
+                validated.last_mut().unwrap()
+            }
+        };
+
+        for table in schema.tables {
+            let validated_table = match validated_schema.tables.iter_mut().find(|t| t.name == table.name) {
+                Some(t) => t,
+                None => {
+                    validated_schema.tables.push(Table::new(table.name));
+                    validated_schema.tables.last_mut().unwrap()
+                }
+            };
+
+            for record in table.records {
+                if record.name.is_some() {
+                    assert!(
+                        validated_table.records.iter().find(|r| r.name == record.name).is_none(),
+                        "Duplicate record '{}' in table '{}.{}'",
+                        record.name.unwrap(),
+                        validated_schema.name,
+                        validated_table.name,
+                    );
+                }
+
+                validated_table.records.push(Record::new(record.name));
+            }
+        }
+    }
+
+    validated
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_valid() {
+        assert_eq!(validate(Vec::new()), Vec::new());
+    }
+
+    #[test]
+    fn two_empty_schemas() {
+        let input = vec![
+            Schema::new("schema1".to_owned()),
+            Schema::new("schema2".to_owned()),
+        ];
+        let output = vec![
+            Schema::new("schema1".to_owned()),
+            Schema::new("schema2".to_owned()),
+        ];
+
+        assert_eq!(validate(input), output);
+    }
+
+    #[test]
+    fn dedupe_schemas() {
+        let input = vec![
+            Schema::new("schema1".to_owned()),
+            Schema::new("schema1".to_owned()),
+        ];
+        let output = vec![
+            Schema::new("schema1".to_owned()),
+        ];
+
+        assert_eq!(validate(input), output);
+
+        let input = vec![
+            Schema::new("schema1".to_owned()),
+            Schema::new("schema2".to_owned()),
+            Schema::new("schema1".to_owned()),
+        ];
+        let output = vec![
+            Schema::new("schema1".to_owned()),
+            Schema::new("schema2".to_owned()),
+        ];
+
+        assert_eq!(validate(input), output);
+    }
+
+    #[test]
+    fn dedupe_schemas_empty_tables() {
+        let input = vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![],
+            },
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table::new("table1".to_owned()),
+                    Table::new("table3".to_owned()),
+                ],
+            },
+            Schema {
+                name: "schema2".to_owned(),
+                tables: vec![
+                    Table::new("table1".to_owned()),
+                ],
+            },
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table::new("table2".to_owned()),
+                ],
+            },
+        ];
+        let output = vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table::new("table1".to_owned()),
+                    Table::new("table3".to_owned()),
+                    Table::new("table2".to_owned()),
+                ]
+            },
+            Schema {
+                name: "schema2".to_owned(),
+                tables: vec![
+                    Table::new("table1".to_owned()),
+                ]
+            },
+        ];
+
+        assert_eq!(validate(input), output);
+    }
+
+    #[test]
+    fn dedupe_tables_with_records() {
+        let actual = validate(vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![],
+            },
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "table1".to_owned(),
+                        records: vec![
+                            Record::new(Some("record2".to_owned())),
+                        ],
+                    },
+                    Table {
+                        name: "table2".to_owned(),
+                        records: vec![
+                            Record::new(None),
+                            Record::new(Some("record1".to_owned())), // Same name as record from public.table1
+                            Record::new(None),
+                        ],
+                    },
+                ],
+            },
+            Schema {
+                name: "schema2".to_owned(),
+                tables: vec![
+                    Table::new("table1".to_owned()),
+                ],
+            },
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "table1".to_owned(),
+                        records: vec![
+                            Record::new(Some("record1".to_owned())),
+                        ],
+                    },
+                ],
+            },
+        ]);
+        let expected = vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "table1".to_owned(),
+                        records: vec![
+                            Record::new(Some("record2".to_owned())),
+                            Record::new(Some("record1".to_owned())),
+                        ],
+                    },
+                    Table {
+                        name: "table2".to_owned(),
+                        records: vec![
+                            Record::new(None),
+                            Record::new(Some("record1".to_owned())),
+                            Record::new(None),
+                        ],
+                    },
+                ],
+            },
+            Schema {
+                name: "schema2".to_owned(),
+                tables: vec![
+                    Table::new("table1".to_owned()),
+                ]
+            },
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Duplicate record 'record1' in table 'schema1.table1'")]
+    fn duplicate_record_names() {
+        validate(vec![
+            Schema {
+                name: "schema1".to_owned(),
+                tables: vec![
+                    Table {
+                        name: "table1".to_owned(),
+                        records: vec![
+                            Record::new(Some("record1".to_owned())),
+                            Record::new(Some("record1".to_owned())),
+                        ],
+                    },
+                ],
+            }
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a basic validator that...

- Combines any schema or table that's declared in several places into single structs
- Asserts that all named records within a table have unique names
- Asserts that all attributes within a single named/anonymous record have unique names

Whether or not it should continue to combine all occurrences of any given schema or table into a single struct is up for debate, but it's easy to change in the future.