### PR TITLE
CLI ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "dotenv",
  "postgres",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dotenv = "0.15.0"
 postgres = "0.19.2"
 
 [dependencies.clap]

--- a/README.md
+++ b/README.md
@@ -22,17 +22,46 @@ Once compiled and installed to your path,
 to run the command you must specify the file to load and the
 database connection string.
 
+These can be specified by the `-f [or --data-file]` and
+`-d [or --database-conn]` options.
+
 ```
 # If installed in path as `hldr`
 $ hldr -f path/to/data/file -d postgres://user:password@host:port/db
 ```
 
+### Default files
+
+There are several alternatives to using the command-line flags.
+
+If the data file is not specified, `hldr` will by default look for a data file named `place.hldr`
+in the current directory.
+
+Additionally, a `.placehldr` file (also in the current directory) can be used to specify either
+or both of the variables. For instance:
+
+```
+# For values with spaces, eg. the key-value connection string format, use double quotes.
+# database_conn="host=localhost dbname=my_database user=postgres"
+database_conn=postgres://postgres@localhost/my_database
+
+# Specifying this means hldr will no longer look for the `place.hldr` default data file.
+# The .hldr extension is recommended but not necessary.
+data_file="my file.hldr"
+```
+
+Any variable in the `.placehldr` file will be overridden in favor of any command-line options
+that are also supplied.
+
+### Committing
+
 By default, Placeholder will roll back the transaction,
-which is useful to test that all records can be created.
+which is useful to test that all records can be created
+before finally applying them.
 If you want to commit the records, pass the `--commit` flag.
 
 ```
-$ hldr -f path/to/data/file -d postgres://user:password@host:port/db --commit
+$ hldr --commit
 ```
 
 ## Features
@@ -120,8 +149,6 @@ that have whitespace, punctuation, etc.
     my_record
       "column with spaces" 42
 ```
-
-
 
 ## Planned features
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod load;
 pub mod parse;
 pub mod validate;
 
-pub fn seed(connstr: &str, filepath: &PathBuf, commit: bool) {
+pub fn place(connstr: &str, filepath: &PathBuf, commit: bool) {
     let text = fs::read_to_string(&filepath).unwrap();
     let tokens = lex::lex(&text);
     let schemas = parse::parse(tokens);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use clap::{Parser, crate_version};
 #[derive(Parser, Debug)]
 #[clap(version = crate_version!())]
 struct Command {
-    /// Connection string - for allowed formats see: https://docs.rs/postgres/0.19.2/postgres/config/struct.Config.html)
+    /// Database connection string - for allowed formats see: https://docs.rs/postgres/0.19.2/postgres/config/struct.Config.html
+
     #[clap(short = 'd', long = "database-conn", name = "CONN")]
     database_conn: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,75 @@
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use clap::{Parser, crate_version};
 
-/// Easy PostgreSQL data seeding
+/// Placeholder: Easy PostgreSQL data seeding
 #[derive(Parser, Debug)]
 #[clap(version = crate_version!())]
-struct Opts {
-    /// Database connection string - for allowed formats see https://docs.rs/postgres/0.19.2/postgres/config/struct.Config.html
+struct Command {
+    /// Connection string - for allowed formats see: https://docs.rs/postgres/0.19.2/postgres/config/struct.Config.html)
     #[clap(short = 'd', long = "database-conn", name = "CONN")]
-    database_connstr: String,
+    database_conn: Option<String>,
 
     /// Path to the data file to load
-    #[clap(short = 'f', long = "file", name = "FILE")]
-    filepath: PathBuf,
+    #[clap(short = 'f', long = "data-file", name = "FILE")]
+    data_file: Option<PathBuf>,
 
-    /// Commits the transaction, which is rolled back by default
+    /// Commit the transaction, rolled back by default
     #[clap(long = "commit")]
     commit: bool
 }
 
+struct Vars {
+    database_conn: Option<String>,
+    data_file: Option<PathBuf>,
+}
+
+impl Vars {
+    fn empty() -> Self {
+        Self { database_conn: None, data_file: None }
+    }
+}
+
 fn main() {
-    let opts: Opts = Opts::parse();
-    hldr::seed(&opts.database_connstr, &opts.filepath, opts.commit);
+    let cmd = Command::parse();
+
+    match (cmd.database_conn, cmd.data_file) {
+        (Some(database_conn), Some(data_file)) => {
+            hldr::place(&database_conn, &data_file, cmd.commit);
+        }
+        (dc, df) => {
+            let vars = vars_from_file();
+            hldr::place(
+                &dc.unwrap_or_else(|| vars.database_conn.expect("database_conn not found in file")),
+                &df.or_else(|| vars.data_file).unwrap_or_else(|| PathBuf::from("place.hldr")),
+                cmd.commit,
+            )
+        }
+    }
+}
+
+fn vars_from_file() -> Vars {
+    let varfile = PathBuf::from(".placehldr");
+
+    if !varfile.exists() {
+        panic!(".placehldr file is missing");
+    }
+
+    if !varfile.is_file() {
+        panic!(".placehldr is not a file");
+    }
+
+    let mut vars = Vars::empty();
+
+    for item in dotenv::from_path_iter(&varfile).unwrap() {
+        let (key, val) = item.unwrap();
+
+        match key.as_ref() {
+            "database_conn" => vars.database_conn = Some(val),
+            "data_file" => vars.data_file = Some(PathBuf::from(&val)),
+            _ => panic!("Unexpected variable: {}", key),
+        }
+    }
+
+    vars
 }


### PR DESCRIPTION
To alleviate having to pass `-d` and `-f` flags on any run, this PR introduces the capacity for `hldr` to look at two different files in the absence of command-line options, both expected to be in the current working directory when executing:

- `place.hldr` as the default data file name
- `.placehldr` as a key-value file allowing one to optionally specify either or both of `database_conn` and `data_file`

Users aren't required to have either of the files:
- If both CLI options are provided, neither file is read or even searched for
- The `.placehldr` file can set the `data_file` variable pointing to a different file than the default `place.hldr`
- Passing the `-d` flag and having a `place.hldr` file will mean `hldr` never looks for `.placehldr`

Additionally, even if both files are present (or if the `.placehldr` defines the `data_file` variable), those values will be overridden if command-line options are supplied.

This addresses https://github.com/kevlarr/hldr/issues/11

(Environment variable options weren't considered; see https://github.com/kevlarr/jrny/issues/21 for rationale)