### PR TITLE
Library error wrapper

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,9 +2,7 @@ use std::{error::Error, fmt};
 
 use postgres::error::Error as PostgresError;
 
-use crate::{lex, parse, validate, load};
-
-//use 
+use crate::{lex, load, parse, validate};
 
 #[derive(Debug)]
 pub enum HldrErrorKind {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,89 @@
+use std::{error::Error, fmt};
+
+use postgres::error::Error as PostgresError;
+
+use crate::{lex, parse, validate, load};
+
+//use 
+
+#[derive(Debug)]
+pub enum HldrErrorKind {
+    LexError,
+    ParseError,
+    ValidateError,
+    ClientError,
+    LoadError,
+    GeneralDatabaseError,
+}
+
+#[derive(Debug)]
+pub struct HldrError {
+    kind: HldrErrorKind,
+    error: Box<dyn Error>,
+}
+
+impl From<lex::LexError> for HldrError {
+    fn from(error: lex::LexError) -> Self {
+        HldrError {
+            kind: HldrErrorKind::LexError,
+            error: Box::new(error),
+        }
+    }
+}
+
+impl From<parse::ParseError> for HldrError {
+    fn from(error: parse::ParseError) -> Self {
+        HldrError {
+            kind: HldrErrorKind::ParseError,
+            error: Box::new(error),
+        }
+    }
+}
+
+impl From<validate::ValidateError> for HldrError {
+    fn from(error: validate::ValidateError) -> Self {
+        HldrError {
+            kind: HldrErrorKind::ValidateError,
+            error: Box::new(error),
+        }
+    }
+}
+
+impl From<load::ClientError> for HldrError {
+    fn from(error: load::ClientError) -> Self {
+        HldrError {
+            kind: HldrErrorKind::ClientError,
+            error: Box::new(error),
+        }
+    }
+}
+
+impl From<load::LoadError> for HldrError {
+    fn from(error: load::LoadError) -> Self {
+        HldrError {
+            kind: HldrErrorKind::LoadError,
+            error: Box::new(error),
+        }
+    }
+}
+
+impl From<PostgresError> for HldrError {
+    fn from(error: PostgresError) -> Self {
+        HldrError {
+            kind: HldrErrorKind::GeneralDatabaseError,
+            error: Box::new(error),
+        }
+    }
+}
+
+impl Error for HldrError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.error.source()
+    }
+}
+
+impl fmt::Display for HldrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.error.fmt(f)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{error:: Error, fs, path::Path};
+use std::{error::Error, fs, path::Path};
 
 pub mod error;
 pub mod lex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,8 @@ fn main() {
                 &df.or(vars.data_file)
                     .unwrap_or_else(|| PathBuf::from("place.hldr")),
                 cmd.commit,
-            ).unwrap()
+            )
+            .unwrap()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
 
     match (cmd.database_conn, cmd.data_file) {
         (Some(database_conn), Some(data_file)) => {
-            hldr::place(&database_conn, &data_file, cmd.commit);
+            hldr::place(&database_conn, &data_file, cmd.commit).unwrap();
         }
         (dc, df) => {
             let vars = vars_from_file();
@@ -48,7 +48,7 @@ fn main() {
                 &df.or(vars.data_file)
                     .unwrap_or_else(|| PathBuf::from("place.hldr")),
                 cmd.commit,
-            )
+            ).unwrap()
         }
     }
 }


### PR DESCRIPTION
https://github.com/kevlarr/hldr/pull/18 did not address the `.unwrap` calls in [`src/lib.rs`](https://github.com/kevlarr/hldr/blob/8261b70bac85ec2ad5f85d6ec18a787079f95c5b/src/lib.rs) so this adds a general error wrapper and defers all unwraps to the executable.

Last step for the first pass at addressing https://github.com/kevlarr/hldr/issues/8