### PR TITLE
Qualified reference values

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ with an indentation style of your choosing. Tabs or 3 spaces?
 Do whatever you want, as long as it's consistent.
 
 Records themselves can either be given a name, or they can be anonymous.
-Named records are not useful yet but they [will be soon](https://github.com/kevlarr/hldr/issues/12).
+Naming records allows their columns (even those populated by the database)
+to be referenced in other records.
 
 There are literal values for booleans, numbers, and text strings.
 
@@ -148,6 +149,24 @@ that have whitespace, punctuation, etc.
   "table.with -- dashes"
     my_record
       "column with spaces" 42
+```
+
+Records can also access values from other, named records using a fully-qualified
+format like `schema.table@record_name.column`.
+Columns do not need to be specified in the file to be referenced,
+such as columns with database defaults like primary keys.
+
+```
+public
+  person
+    fry
+      name 'Philip J. Fry'
+
+  pet
+    seymour
+      name 'Seymour Asses'
+      species 'Dog'
+      person_id public.person@fry.id
 ```
 
 ## Planned features

--- a/src/lex/error.rs
+++ b/src/lex/error.rs
@@ -16,6 +16,7 @@ impl fmt::Display for Position {
 #[derive(Clone, Debug, PartialEq)]
 pub enum LexErrorKind {
     ExpectedComment,
+    ExpectedNumber,
     UnclosedQuotedIdentifier,
     UnclosedString,
     UnexpectedCharacter(char),
@@ -35,6 +36,12 @@ impl LexError {
         }
     }
 
+    pub fn expected_number(position: Position) -> Self {
+        Self {
+            kind: LexErrorKind::ExpectedNumber,
+            position,
+        }
+    }
     pub fn unclosed_quoted_identifier(position: Position) -> Self {
         Self {
             kind: LexErrorKind::UnclosedQuotedIdentifier,
@@ -68,10 +75,11 @@ impl fmt::Display for LexError {
         use LexErrorKind::*;
 
         match self.kind {
-            ExpectedComment => write!(f, "Expected comment {}", self.position,),
-            UnclosedQuotedIdentifier => write!(f, "Unclosed quoted identifier {}", self.position,),
-            UnclosedString => write!(f, "Unclosed string {}", self.position,),
-            UnexpectedCharacter(c) => write!(f, "Unexpected character `{}` {}", c, self.position,),
+            ExpectedComment => write!(f, "Expected comment {}", self.position),
+            ExpectedNumber => write!(f, "Expected number {}", self.position),
+            UnclosedQuotedIdentifier => write!(f, "Unclosed quoted identifier {}", self.position),
+            UnclosedString => write!(f, "Unclosed string {}", self.position),
+            UnexpectedCharacter(c) => write!(f, "Unexpected character `{}` {}", c, self.position),
         }
     }
 }

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -267,6 +267,59 @@ mod tests {
     }
 
     #[test]
+    fn at_sign_alone() {
+        assert_eq!(
+            lex("@"),
+            Err(E {
+                position: P { line: 1, column: 1 },
+                kind: K::UnexpectedCharacter('@'),
+            })
+        );
+        assert_eq!(
+            lex("\t\t@"),
+            Err(E {
+                position: P { line: 1, column: 3 },
+                kind: K::UnexpectedCharacter('@'),
+            })
+        );
+    }
+
+    #[test]
+    fn at_sign_identifiers_whitespace_before() {
+        assert_eq!(
+            lex("some @identifiers"),
+            Err(E {
+                position: P { line: 1, column: 6 },
+                kind: K::UnexpectedCharacter('@'),
+            })
+        );
+    }
+
+    #[test]
+    fn at_sign_identifiers_whitespace_after() {
+        assert_eq!(
+            lex("some@ identifiers"),
+            Err(E {
+                position: P { line: 1, column: 6 },
+                kind: K::UnexpectedCharacter(' '),
+            })
+        );
+    }
+
+    #[test]
+    fn at_sign_in_identifiers() {
+        assert_eq!(
+            lex("some@identifier"),
+            Ok(vec![
+              T::Identifier("some".to_owned()),
+              T::AtSign,
+              T::Identifier("identifier".to_owned()),
+              T::Newline,
+            ])
+        );
+    }
+
+    #[test]
     fn good_file() {
         let file = r#"public
   -- This is a newline comment

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -65,6 +65,7 @@ fn literal_value(v: &Value) -> String {
         Value::Boolean(b) => b.to_string(),
         Value::Number(n) => n.clone(),
         Value::Text(t) => format!("'{}'", t),
+        _ => panic!("Value not supported: {:?}", v),
     }
 }
 

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -1,10 +1,10 @@
 mod error;
 
-use std::{str::FromStr, time::Duration};
+use std::{collections::HashMap, str::FromStr, time::Duration};
 
-use postgres::{config::Config, Client, NoTls, Transaction};
+use postgres::{config::Config, Client, NoTls, SimpleQueryMessage, SimpleQueryRow, Transaction};
 
-use super::{parse::Value, validate::ValidatedSchemas};
+use super::{parse::Value, validate::{Item, ValidatedSchemas, ValidatedAttributes}};
 pub use error::{ClientError, LoadError};
 
 pub fn new_client(connstr: &str) -> Result<Client, ClientError> {
@@ -19,56 +19,110 @@ pub fn new_client(connstr: &str) -> Result<Client, ClientError> {
     config.connect(NoTls).map_err(ClientError::connection_error)
 }
 
-pub fn load(transaction: &mut Transaction, validated: &ValidatedSchemas) -> Result<(), LoadError> {
-    /*
-    for schema in validated.schemas() {
-        for table in &schema.tables {
-            for record in &table.records {
-                let mut columns = Vec::new();
-                let mut values = Vec::new();
-
-                for attr in &record.attributes {
-                    columns.push(&attr.name);
-                    values.push(&attr.value);
-                }
-
-                let columns_string = columns
-                    .into_iter()
-                    .map(|c| format!("\"{}\"", c))
-                    .collect::<Vec<String>>()
-                    .join(", ");
-
-                let values_string = values
-                    .into_iter()
-                    .map(literal_value)
-                    .collect::<Vec<String>>()
-                    .join(", ");
-
-                let statement = format!(
-                    r#"
-                    INSERT INTO "{}"."{}" ({}) VALUES ({})
-                "#,
-                    schema.name, table.name, columns_string, values_string,
-                );
-
-                transaction
-                    .execute(&statement, &[])
-                    .map_err(LoadError::new)?;
-            }
-        }
-    }
-    */
-
-    Ok(())
+struct Loader<'a, 'b>
+where 'b: 'a {
+    named_records: HashMap<String, SimpleQueryRow>,
+    transaction: &'a mut Transaction<'b>,
 }
 
-fn literal_value(v: &Value) -> String {
-    match v {
-        Value::Boolean(b) => b.to_string(),
-        Value::Number(n) => n.clone(),
-        Value::Text(t) => format!("'{}'", t),
-        _ => panic!("Value not supported: {:?}", v),
+impl<'a, 'b> Loader<'a, 'b> {
+    fn new(transaction: &'a mut Transaction<'b>) -> Self {
+        Self {
+            named_records: HashMap::new(),
+            transaction,
+        }
     }
+
+    fn load(&mut self, validated: &ValidatedSchemas) -> Result<(), LoadError> {
+        for schema in validated.schemas().items() {
+            for table in schema.tables().items() {
+                for record in table.named_records().items() {
+                    let qualified_name = format!("{}.{}@{}", schema.name(), table.name(), record.name());
+                    let row = self.insert(
+                        schema.name(),
+                        table.name(),
+                        record.attributes(),
+                    )?;
+                    self.named_records.insert(qualified_name, row);
+                }
+
+                for record in table.anonymous_records().items() {
+                    self.insert(
+                        schema.name(),
+                        table.name(),
+                        record.attributes(),
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert(&mut self, schema: &str, table: &str, attrs: &ValidatedAttributes) -> Result<SimpleQueryRow, LoadError> {
+        let mut columns = Vec::new();
+        let mut values = Vec::new();
+
+        for attr in attrs.items() {
+            columns.push(attr.name());
+            values.push(attr.value());
+        }
+
+        let columns_string = columns
+            .into_iter()
+            .map(|c| format!("\"{}\"", c))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let values_string = values
+            .into_iter()
+            .map(|v| self.literal_value(v))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let statement = format!(
+            r#"
+            INSERT INTO "{}"."{}" ({}) VALUES ({})
+            RETURNING *
+        "#,
+            schema, table, columns_string, values_string,
+        );
+
+        let resp = self.transaction
+            .simple_query(&statement)
+            .map_err(LoadError::new)?
+            .remove(0);
+
+        match resp {
+            SimpleQueryMessage::Row(row) => Ok(row),
+            _ => unreachable!(),
+        }
+    }
+
+
+    fn literal_value(&self, v: &Value) -> String {
+        match v {
+            Value::Boolean(b) => b.to_string(),
+            Value::Number(n) => n.clone(),
+            Value::Text(t) => format!("'{}'", t),
+            Value::Reference(refval) => {
+                let col = refval.column.as_str();
+                
+                let qualified_name = format!("{}.{}@{}", refval.schema, refval.table, refval.record);
+                let row = self.named_records.get(&qualified_name).unwrap();
+                let val = row.try_get(col);
+
+                val
+                    .expect(&format!("no column '{}' in record {}", col, qualified_name))
+                    .map_or_else(|| "null".to_owned(), |v| format!("'{}'", v))
+            },
+        }
+    }
+}
+
+pub fn load(transaction: &mut Transaction, validated: &ValidatedSchemas) -> Result<(), LoadError> {
+    Loader::new(transaction).load(validated)
+
 }
 
 #[cfg(test)]
@@ -77,12 +131,32 @@ mod load_tests {
 
     use chrono::prelude::*;
 
-    use super::super::parse::{Attribute, Record, Schema, Table, Value};
+    use super::super::parse::{Attribute, Record, Schema, Table, Value, ReferenceValue};
     use super::super::validate::validate;
     use super::*;
 
     #[test]
     fn loads() {
+        let mut client = new_client(&env::var("HLDR_TEST_DATABASE_URL").unwrap()).unwrap();
+        let mut transaction = client.transaction().unwrap();
+
+        transaction.simple_query("
+            CREATE SCHEMA hldr_test_schema;
+
+            CREATE TABLE hldr_test_schema.table1  (
+                id serial primary key,
+                column1 bool,
+                column2 int,
+                column3 timestamptz
+            );
+
+            CREATE TABLE hldr_test_schema.table2  (
+                id serial primary key,
+                table1_id int,
+                column2 int
+            );
+        ").unwrap();
+
         let validated = validate(vec![Schema {
             name: "hldr_test_schema".to_owned(),
             tables: vec![Table {
@@ -106,7 +180,7 @@ mod load_tests {
                         ],
                     },
                     Record {
-                        name: Some("record".to_owned()),
+                        name: Some("record1".to_owned()),
                         attributes: vec![
                             Attribute {
                                 name: "column1".to_owned(),
@@ -123,62 +197,83 @@ mod load_tests {
                         ],
                     },
                 ],
+            }, Table {
+                name: "table2".to_owned(),
+                records: vec![
+                    Record {
+                        name: None,
+                        attributes: vec![
+                            Attribute {
+                                name: "table1_id".to_owned(),
+                                value: Value::Reference(Box::new(ReferenceValue {
+                                    schema: "hldr_test_schema".to_owned(),
+                                    table: "table1".to_owned(),
+                                    record: "record1".to_owned(),
+                                    column: "id".to_owned(),
+                                })),
+                            },
+                        ],
+                    },
+                    Record {
+                        name: None,
+                        attributes: vec![
+                            Attribute {
+                                name: "column2".to_owned(),
+                                value: Value::Reference(Box::new(ReferenceValue {
+                                    schema: "hldr_test_schema".to_owned(),
+                                    table: "table1".to_owned(),
+                                    record: "record1".to_owned(),
+                                    column: "column2".to_owned(),
+                                })),
+                            },
+                        ],
+                    },
+                ],
             }],
         }])
         .unwrap();
 
-        let mut client = new_client(&env::var("HLDR_TEST_DATABASE_URL").unwrap()).unwrap();
-        let mut transaction = client.transaction().unwrap();
-
-        transaction
-            .execute(
-                "
-            CREATE SCHEMA hldr_test_schema
-        ",
-                &[],
-            )
-            .unwrap();
-        transaction
-            .execute(
-                "
-            CREATE TABLE  hldr_test_schema.table1  (
-                id serial primary key,
-                column1 bool,
-                column2 int,
-                column3 timestamptz
-            )
-        ",
-                &[],
-            )
-            .unwrap();
-
         load(&mut transaction, &validated).unwrap();
 
-        let rows = transaction
-            .query(
-                "
-            SELECT column1, column2, column3 FROM hldr_test_schema.table1
+        // FIXME: Why is this DESC..?
+        let rows = transaction.query("
+            SELECT id, column1, column2, column3
+            FROM hldr_test_schema.table1
             ORDER BY id DESC
-        ",
-                &[],
-            )
-            .unwrap();
+        ", &[]).unwrap();
 
         assert_eq!(rows.len(), 2);
 
-        assert!(!rows[0].get::<&str, bool>("column1"));
-        assert!(rows[1].get::<&str, bool>("column1"));
+        assert!(rows[0].get::<&str, bool>("column1"));
+        assert!(!rows[1].get::<&str, bool>("column1"));
 
-        assert_eq!(rows[0].get::<&str, i32>("column2"), 12345);
-        assert_eq!(rows[1].get::<&str, i32>("column2"), 13); // Decimals were truncated
+        assert_eq!(rows[0].get::<&str, i32>("column2"), 13); // Decimals were truncated
+        assert_eq!(rows[1].get::<&str, i32>("column2"), 12345);
 
         assert_eq!(
             rows[0].get::<&str, DateTime<Utc>>("column3"),
-            Utc.ymd(2021, 11, 30).and_hms(5, 0, 0)
+            Utc.ymd(2021, 11, 28).and_hms(17, 0, 0)
         );
         assert_eq!(
             rows[1].get::<&str, DateTime<Utc>>("column3"),
-            Utc.ymd(2021, 11, 28).and_hms(17, 0, 0)
+            Utc.ymd(2021, 11, 30).and_hms(5, 0, 0)
+        );
+
+        let record1_id = rows[1].get::<&str, i32>("id");
+
+        let rows = transaction.query("
+            SELECT table1_id, column2
+            FROM hldr_test_schema.table2
+            ORDER BY id ASC
+        ", &[]).unwrap();
+
+        assert_eq!(
+            rows[0].get::<&str, i32>("table1_id"),
+            record1_id,
+        );
+        assert_eq!(
+            rows[1].get::<&str, i32>("column2"),
+            12345,
         );
     }
 }

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -20,6 +20,7 @@ pub fn new_client(connstr: &str) -> Result<Client, ClientError> {
 }
 
 pub fn load(transaction: &mut Transaction, validated: &ValidatedSchemas) -> Result<(), LoadError> {
+    /*
     for schema in validated.schemas() {
         for table in &schema.tables {
             for record in &table.records {
@@ -56,6 +57,7 @@ pub fn load(transaction: &mut Transaction, validated: &ValidatedSchemas) -> Resu
             }
         }
     }
+    */
 
     Ok(())
 }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -127,6 +127,7 @@ impl fmt::Display for ParseError {
                     Token::Indent(_) => write!(f, "indent")?,
                     Token::Newline => write!(f, "newline")?,
                     Token::Number(_) => write!(f, "number")?,
+                    Token::Period => write!(f, "'.'")?,
                     Token::QuotedIdentifier(i) => write!(f, "quoted identifier `\"{}\"`", i)?,
                     Token::Text(_) => write!(f, "string")?,
                     Token::Underscore => write!(f, "underscore")?,

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -4,6 +4,7 @@ use super::Token;
 
 #[derive(Debug, PartialEq)]
 pub enum ParseErrorKind {
+    IncompleteReference(String),
     InconsistentIndent { unit: String, received: String },
     MissingColumnValue,
     MissingRecord,
@@ -35,6 +36,13 @@ impl ParseError {
     pub fn inconsistent_indent(line: usize, unit: String, received: String) -> Self {
         Self {
             kind: ParseErrorKind::InconsistentIndent { unit, received },
+            line,
+        }
+    }
+
+    pub fn incomplete_reference(line: usize, reference: String) -> Self {
+        Self {
+            kind: ParseErrorKind::IncompleteReference(reference),
             line,
         }
     }
@@ -101,13 +109,16 @@ impl fmt::Display for ParseError {
 
         match &self.kind {
             EmptyIndent => write!(f, "Empty indent on line {}", self.line,),
+            IncompleteReference(reference) => {
+                write!(f, "Incomplete reference '{}' on line {}", reference, self.line)
+            }
             InconsistentIndent { unit, received } => write!(
                 f,
                 "Expected indentation unit of '{}', received '{}' on line {}",
                 unit, received, self.line,
             ),
             InvalidIndent(indent) => {
-                write!(f, "Invalid indentation '{}' on line {}", indent, self.line,)
+                write!(f, "Invalid indentation '{}' on line {}", indent, self.line)
             }
             MissingColumnValue => write!(f, "Missing column value on line {}", self.line,),
             MissingRecord => write!(f, "No record present for column on line {}", self.line,),

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -121,6 +121,7 @@ impl fmt::Display for ParseError {
             UnexpectedToken(t) => {
                 write!(f, "Unexpected ")?;
                 match t {
+                    Token::AtSign => write!(f, "'@'")?,
                     Token::Boolean(b) => write!(f, "`{}`", b)?,
                     Token::Identifier(i) => write!(f, "identifier `{}`", i)?,
                     Token::Indent(_) => write!(f, "indent")?,

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -6,7 +6,7 @@ pub use error::{ParseError, ParseErrorKind};
 use parser::Parser;
 
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ReferenceValue {
     pub schema: String,
     pub table: String,

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -5,11 +5,21 @@ use super::lex::Token;
 pub use error::{ParseError, ParseErrorKind};
 use parser::Parser;
 
+
+#[derive(Debug, PartialEq)]
+pub struct ReferenceValue {
+    pub schema: String,
+    pub table: String,
+    pub record: String,
+    pub column: String,
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Value {
     Boolean(bool),
     Number(String),
     Text(String),
+    Reference(Box<ReferenceValue>)
 }
 
 #[derive(Debug, PartialEq)]
@@ -70,6 +80,7 @@ pub fn parse(tokens: Vec<Token>) -> Result<Vec<Schema>, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::{Token as T, *};
+    use super::super::lex::lex;
 
     #[test]
     fn empty() {
@@ -254,15 +265,11 @@ mod tests {
 
     #[test]
     fn named_record() {
-        let tokens = vec![
-            T::Identifier("public".to_owned()),
-            T::Newline,
-            T::Indent("  ".to_owned()),
-            T::Identifier("person".to_owned()),
-            T::Newline,
-            T::Indent("    ".to_owned()),
-            T::Identifier("kevin".to_owned()),
-        ];
+        let tokens = lex(
+"public
+  person
+    kevin"
+        ).unwrap();
 
         assert_eq!(
             parse(tokens),
@@ -281,27 +288,15 @@ mod tests {
 
     #[test]
     fn named_records() {
-        let tokens = vec![
-            T::Identifier("public".to_owned()),
-            T::Newline,
-            T::Indent("  ".to_owned()),
-            T::Identifier("person".to_owned()),
-            T::Newline,
-            T::Indent("    ".to_owned()),
-            T::Identifier("stacey".to_owned()),
-            T::Newline,
-            T::Indent("    ".to_owned()),
-            T::Identifier("kevin".to_owned()),
-            T::Newline,
-            T::Indent("  ".to_owned()),
-            T::Identifier("pet".to_owned()),
-            T::Newline,
-            T::Indent("    ".to_owned()),
-            T::Identifier("eiyre".to_owned()),
-            T::Newline,
-            T::Indent("    ".to_owned()),
-            T::Identifier("cupid".to_owned()),
-        ];
+        let tokens = lex(
+"public
+  person
+    stacey
+    kevin
+  pet
+    eiyre
+    cupid"
+        ).unwrap();
 
         assert_eq!(
             parse(tokens),
@@ -509,7 +504,105 @@ mod tests {
     }
 
     #[test]
-    fn attribute() {
+    fn boolean_attribute() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("likes_coffee".to_owned()),
+            T::Boolean(true),
+        ];
+
+        assert_eq!(
+            parse(tokens),
+            Ok(vec![Schema {
+                name: "public".to_owned(),
+                tables: vec![Table {
+                    name: "person".to_owned(),
+                    records: vec![Record {
+                        name: Some("kevin".to_owned()),
+                        attributes: vec![Attribute {
+                            name: "likes_coffee".to_owned(),
+                            value: Value::Boolean(true),
+                        }]
+                    }]
+                }]
+            },])
+        );
+    }
+
+    #[test]
+    fn number_attribute() {
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("pets".to_owned()),
+            T::Number("2".to_owned()),
+        ];
+
+        assert_eq!(
+            parse(tokens),
+            Ok(vec![Schema {
+                name: "public".to_owned(),
+                tables: vec![Table {
+                    name: "person".to_owned(),
+                    records: vec![Record {
+                        name: Some("kevin".to_owned()),
+                        attributes: vec![Attribute {
+                            name: "pets".to_owned(),
+                            value: Value::Number("2".to_owned()),
+                        }]
+                    }]
+                }]
+            }])
+        );
+        let tokens = vec![
+            T::Identifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::Identifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::Identifier("pets".to_owned()),
+            T::Number("2.5".to_owned()),
+        ];
+
+        assert_eq!(
+            parse(tokens),
+            Ok(vec![Schema {
+                name: "public".to_owned(),
+                tables: vec![Table {
+                    name: "person".to_owned(),
+                    records: vec![Record {
+                        name: Some("kevin".to_owned()),
+                        attributes: vec![Attribute {
+                            name: "pets".to_owned(),
+                            value: Value::Number("2.5".to_owned()),
+                        }]
+                    }]
+                }]
+            }])
+        );
+    }
+
+    #[test]
+    fn text_attribute() {
         let tokens = vec![
             T::Identifier("public".to_owned()),
             T::Newline,
@@ -535,6 +628,81 @@ mod tests {
                         attributes: vec![Attribute {
                             name: "name".to_owned(),
                             value: Value::Text("Kevin".to_owned()),
+                        }]
+                    }]
+                }]
+            },])
+        );
+    }
+
+    #[test]
+    fn fully_qualified_reference_attribute() {
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema.table@record.column2"
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Ok(vec![Schema {
+                name: "public".to_owned(),
+                tables: vec![Table {
+                    name: "person".to_owned(),
+                    records: vec![Record {
+                        name: Some("kevin".to_owned()),
+                        attributes: vec![Attribute {
+                            name: "column1".to_owned(),
+                            value: Value::Reference(Box::new(ReferenceValue {
+                                schema: "schema".to_owned(),
+                                table: "table".to_owned(),
+                                record: "record".to_owned(),
+                                column: "column2".to_owned(),
+                            })),
+                        }]
+                    }]
+                }]
+            },])
+        );
+
+        let tokens = vec![
+            T::QuotedIdentifier("public".to_owned()),
+            T::Newline,
+            T::Indent("\t".to_owned()),
+            T::QuotedIdentifier("person".to_owned()),
+            T::Newline,
+            T::Indent("\t\t".to_owned()),
+            T::Identifier("kevin".to_owned()),
+            T::Newline,
+            T::Indent("\t\t\t".to_owned()),
+            T::QuotedIdentifier("column1".to_owned()),
+            T::QuotedIdentifier("schema".to_owned()),
+            T::Period,
+            T::QuotedIdentifier("table".to_owned()),
+            T::AtSign,
+            T::QuotedIdentifier("record".to_owned()),
+            T::Period,
+            T::QuotedIdentifier("column2".to_owned()),
+            T::Newline,
+        ];
+
+        assert_eq!(
+            parse(tokens),
+            Ok(vec![Schema {
+                name: "public".to_owned(),
+                tables: vec![Table {
+                    name: "person".to_owned(),
+                    records: vec![Record {
+                        name: Some("kevin".to_owned()),
+                        attributes: vec![Attribute {
+                            name: "column1".to_owned(),
+                            value: Value::Reference(Box::new(ReferenceValue {
+                                schema: "schema".to_owned(),
+                                table: "table".to_owned(),
+                                record: "record".to_owned(),
+                                column: "column2".to_owned(),
+                            })),
                         }]
                     }]
                 }]
@@ -652,6 +820,7 @@ mod tests {
             T::Newline,
             T::Indent("\t\t\t".to_owned()),
             T::Boolean(false),
+            T::Newline,
         ];
 
         assert_eq!(
@@ -673,6 +842,7 @@ mod tests {
             T::Newline,
             T::Indent("\t\t\t".to_owned()),
             T::Identifier("name".to_owned()),
+            T::Newline,
         ];
 
         assert_eq!(parse(tokens), Err(ParseError::missing_column_value(4)));
@@ -720,6 +890,84 @@ mod tests {
                 4,
                 T::Identifier("name".to_owned())
             ))
+        );
+    }
+
+    #[test]
+    fn attribute_with_incomplete_fully_qualified_reference() {
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema1"
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Err(ParseError::unexpected_token(
+                4,
+                T::Identifier("schema1".to_owned())
+            ))
+        );
+
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema1."
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Err(ParseError::incomplete_reference(4, "schema1.".to_owned()))
+        );
+
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema1.table1"
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Err(ParseError::incomplete_reference(4, "schema1.table1".to_owned()))
+        );
+
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema1.table1@"
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Err(ParseError::incomplete_reference(4, "schema1.table1@".to_owned()))
+        );
+
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema1.table1@record1"
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Err(ParseError::incomplete_reference(4, "schema1.table1@record1".to_owned()))
+        );
+
+        let tokens = lex(
+"public
+  person
+    kevin
+      column1 schema1.table1@record1."
+        ).unwrap();
+
+        assert_eq!(
+            parse(tokens),
+            Err(ParseError::incomplete_reference(4, "schema1.table1@record1.".to_owned()))
         );
     }
 

--- a/src/validate/error.rs
+++ b/src/validate/error.rs
@@ -1,11 +1,17 @@
 use std::{error::Error, fmt};
 
+use crate::parse::ReferenceValue;
+
 #[derive(Debug, PartialEq)]
 pub enum ValidateErrorKind {
     DuplicateRecordName(String),
     DuplicateColumn {
         record: Option<String>,
         column: String,
+    },
+    UnknownRecord {
+        record: Option<String>,
+        reference: ReferenceValue,
     },
 }
 
@@ -34,8 +40,21 @@ impl fmt::Display for ValidateError {
             ),
             DuplicateColumn { record, column } => write!(
                 f,
-                "Duplicate column '{}' for record '{}' in '{}.{}'",
+                "Duplicate column '{}' for {} in '{}.{}'",
                 column,
+                record
+                    .as_ref()
+                    .map(|name| format!("record '{}'", name))
+                    .unwrap_or_else(|| "anonymous record".to_owned()),
+                self.schema,
+                self.table,
+            ),
+            UnknownRecord { record, reference } => write!(
+                f,
+                "Cannot find record {}.{}@{} referenced by {} in '{}.{}'",
+                reference.schema,
+                reference.table,
+                reference.record,
                 record
                     .as_ref()
                     .map(|name| format!("record '{}'", name))

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -1,6 +1,8 @@
 mod types;
 pub mod error;
 
+use std::collections::HashSet;
+
 use super::parse::*;
 pub use types::*;
 pub use error::{ValidateError, ValidateErrorKind};
@@ -8,6 +10,10 @@ pub use error::{ValidateError, ValidateErrorKind};
 
 pub fn validate(schemas: Vec<Schema>) -> Result<ValidatedSchemas, ValidateError> {
     let mut vschemas = ValidatedSchemas::new();
+
+    // TODO: This is a hack to work around borrow issues when trying to
+    // check vschemas directly for reference values
+    let mut named_records: HashSet<String> = HashSet::new();
 
     for schema in schemas {
         let vschema = vschemas.schemas_mut().get_or_create_mut(&schema.name);
@@ -17,17 +23,24 @@ pub fn validate(schemas: Vec<Schema>) -> Result<ValidatedSchemas, ValidateError>
 
             for record in table.records {
                 let vattrs = match &record.name {
-                    Some(name) => {
-                        if vtable.named_records().contains_key(name) {
+                    Some(record_name) => {
+                        if vtable.named_records().contains_key(record_name) {
                             return Err(ValidateError {
-                                kind: ValidateErrorKind::DuplicateRecordName(name.to_owned()),
+                                kind: ValidateErrorKind::DuplicateRecordName(record_name.to_owned()),
                                 schema: schema.name,
                                 table: table.name,
                             });
                         }
 
+                        named_records.insert(format!(
+                            "{}.{}@{}",
+                            schema.name,
+                            table.name,
+                            record_name,
+                        ));
+
                         // TODO: vtable shouldn't use `get_or_create_mut`
-                        vtable.named_records_mut().get_or_create_mut(name).attributes_mut()
+                        vtable.named_records_mut().get_or_create_mut(record_name).attributes_mut()
                     },
                     None => vtable.anonymous_records_mut().create().attributes_mut(),
                 };
@@ -44,10 +57,25 @@ pub fn validate(schemas: Vec<Schema>) -> Result<ValidatedSchemas, ValidateError>
                         });
                     }
 
-                    //if let Value::Reference(r) = &attribute.value {
-                        //let record_present = validated.iter()
-                            //.find(|v| v.name == r.schema);
-                    //}
+                    if let Value::Reference(refval) = &attribute.value {
+                        let qualified_record_name = format!(
+                            "{}.{}@{}",
+                            refval.schema,
+                            refval.table,
+                            refval.record,
+                        );
+
+                        if !named_records.contains(&qualified_record_name) {
+                            return Err(ValidateError {
+                                kind: ValidateErrorKind::UnknownRecord {
+                                    reference: (**refval).clone(),
+                                    record: record.name,
+                                },
+                                schema: schema.name,
+                                table: table.name,
+                            });
+                        }
+                    }
 
                     vattrs.add(ValidatedAttribute::new(attribute));
                 }
@@ -387,9 +415,14 @@ mod validate_tests {
                 }],
             }]),
             Err(ValidateError {
-                kind: ValidateErrorKind::DuplicateColumn {
+                kind: ValidateErrorKind::UnknownRecord {
+                    reference: ReferenceValue {
+                        schema: "schema2".to_owned(),
+                        table: "table2".to_owned(),
+                        record: "record2".to_owned(),
+                        column: "column2".to_owned(),
+                    },
                     record: Some("my_record".to_owned()),
-                    column: "attr1".to_owned(),
                 },
                 schema: "schema1".to_owned(),
                 table: "table1".to_owned(),
@@ -399,9 +432,107 @@ mod validate_tests {
 
     #[test]
     fn reference_value_comes_before_record() {
+        assert_eq!(
+            validate(vec![Schema {
+                name: "schema1".to_owned(),
+                tables: vec![Table {
+                    name: "table1".to_owned(),
+                    records: vec![Record {
+                        name: None,
+                        attributes: vec![
+                            Attribute {
+                                name: "column1".to_owned(),
+                                value: Value::Reference(Box::new(ReferenceValue {
+                                    schema: "schema1".to_owned(),
+                                    table: "table2".to_owned(),
+                                    record: "record2".to_owned(),
+                                    column: "column2".to_owned(),
+                                })),
+                            },
+                        ],
+                    }],
+                }, Table {
+                    name: "table2".to_owned(),
+                    records: vec![Record {
+                        name: Some("record2".to_owned()),
+                        attributes: vec![/* -- column doesn't need to exist
+                            Attribute {
+                                name: "column2".to_owned(),
+                                value: Value::Reference(Box::new(ReferenceValue {
+                                    schema: "schema2".to_owned(),
+                                    table: "table2".to_owned(),
+                                    record: "record2".to_owned(),
+                                    column: "column2".to_owned(),
+                                })),
+                            },
+                        */],
+                    }],
+                }],
+            }]),
+            Err(ValidateError {
+                kind: ValidateErrorKind::UnknownRecord {
+                    reference: ReferenceValue {
+                        schema: "schema1".to_owned(),
+                        table: "table2".to_owned(),
+                        record: "record2".to_owned(),
+                        column: "column2".to_owned(),
+                    },
+                    record: None,
+                },
+                schema: "schema1".to_owned(),
+                table: "table1".to_owned(),
+            })
+        );
     }
 
     #[test]
     fn reference_value_good() {
+        let input = vec![Schema {
+            name: "schema1".to_owned(),
+            tables: vec![Table {
+                name: "table1".to_owned(),
+                records: vec![Record {
+                    name: Some("record1".to_owned()),
+                    // The referenced column doesn't need to be declared,
+                    // since it could be coming from database default, etc.
+                    attributes: Vec::new(),
+                }],
+            }, Table {
+                name: "table2".to_owned(),
+                records: vec![Record {
+                    name: None,
+                    attributes: vec![
+                        Attribute {
+                            name: "column1".to_owned(),
+                            value: Value::Reference(Box::new(ReferenceValue {
+                                schema: "schema1".to_owned(),
+                                table: "table1".to_owned(),
+                                record: "record1".to_owned(),
+                                column: "blimey".to_owned(),
+                            })),
+                        },
+                    ],
+                }],
+            }],
+        }];
+
+        let mut expected = ValidatedSchemas::new();
+        let schema1 = expected.schemas_mut().get_or_create_mut("schema1");
+        let table1 = schema1.tables_mut().get_or_create_mut("table1");
+        table1.named_records_mut().get_or_create_mut("record1");
+
+        let table2 = schema1.tables_mut().get_or_create_mut("table2");
+        let attrs = table2.anonymous_records_mut().create().attributes_mut();
+        attrs.add(ValidatedAttribute::new(Attribute {
+            name: "column1".to_owned(),
+            value: Value::Reference(Box::new(ReferenceValue {
+                schema: "schema1".to_owned(),
+                table: "table1".to_owned(),
+                record: "record1".to_owned(),
+                column: "blimey".to_owned(),
+            })),
+        }));
+
+        assert_eq!(validate(input), Ok(expected));
     }
 }

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -289,7 +289,6 @@ mod validate_tests {
         assert_eq!(validate(input), Ok(expected));
     }
 
-    /*
     #[test]
     fn duplicate_attribute_names_anonymous() {
         assert_eq!(
@@ -405,5 +404,4 @@ mod validate_tests {
     #[test]
     fn reference_value_good() {
     }
-     */
 }

--- a/src/validate/types.rs
+++ b/src/validate/types.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+
+use crate::parse::Attribute;
+
+pub trait Item {
+    fn name(&self) -> &str;
+}
+
+/// Collection type to allow storing ordered items while also
+/// allowing lookup by key name
+#[derive(Debug, PartialEq)]
+pub struct OrderedHashMap<T: Item> {
+    items: Vec<T>,
+    map: HashMap<String, usize>,
+}
+
+impl<T: Item> OrderedHashMap<T> {
+    pub fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn add(&mut self, item: T) {
+        if self.contains_key(&item.name()) {
+            panic!("already contains {}", item.name());
+        }
+
+        let item_name = item.name().to_owned();
+
+        self.items.push(item);
+        self.map.insert(item_name, self.items.len() - 1);
+    }
+}
+
+impl<T: Item + From<String>> OrderedHashMap<T> {
+    pub fn get_or_create_mut(&mut self, key: impl Into<String>) -> &mut T {
+        let key: String = key.into();
+
+        let index = match self.map.get(&key) {
+            Some(i) => i,
+            None => {
+                self.items.push(T::from(key.clone()));
+                self.map.insert(key.to_owned(), self.items.len() - 1);
+                self.map.get(&key).unwrap()
+            }
+        };
+
+        &mut self.items[*index]
+    }
+}
+
+/// An attribute that has been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedAttribute(Attribute);
+
+impl ValidatedAttribute {
+    pub fn new(attr: Attribute) -> Self {
+        Self(attr)
+    }
+}
+
+impl Item for ValidatedAttribute {
+    fn name(&self) -> &str {
+        &self.0.name
+    }
+}
+
+/// A named record whose attributes have all been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedNamedRecord {
+    name: String,
+    attributes: OrderedHashMap<ValidatedAttribute>,
+}
+
+impl ValidatedNamedRecord {
+    pub(super) fn attributes_mut(&mut self) -> &mut OrderedHashMap<ValidatedAttribute> {
+        &mut self.attributes
+    }
+}
+
+impl From<String> for ValidatedNamedRecord {
+    fn from(s: String) -> Self {
+        Self {
+            name: s.into(),
+            attributes: OrderedHashMap::new(),
+        }
+    }
+}
+
+impl Item for ValidatedNamedRecord {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// An anonymous record whose attributes have all been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedAnonymousRecord {
+    attributes: OrderedHashMap<ValidatedAttribute>,
+}
+
+impl ValidatedAnonymousRecord {
+    pub fn new() -> Self {
+        Self {
+            attributes: OrderedHashMap::new()
+        }
+    }
+
+    pub(super) fn attributes_mut(&mut self) -> &mut OrderedHashMap<ValidatedAttribute> {
+        &mut self.attributes
+    }
+}
+
+/// A collection of anonymous records that have all been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedAnonymousRecords(Vec<ValidatedAnonymousRecord>);
+
+impl ValidatedAnonymousRecords {
+    pub(super) fn create(&mut self) -> &mut ValidatedAnonymousRecord {
+        self.0.push(ValidatedAnonymousRecord::new());
+        self.0.last_mut().unwrap()
+    }
+}
+
+/// A table whose named and anonymous records have all been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedTable {
+    name: String,
+    named_records: OrderedHashMap<ValidatedNamedRecord>,
+    anonymous_records: ValidatedAnonymousRecords,
+}
+
+impl ValidatedTable {
+    pub fn anonymous_records(&self) -> &ValidatedAnonymousRecords {
+        &self.anonymous_records
+    }
+
+    pub(super) fn anonymous_records_mut(&mut self) -> &mut ValidatedAnonymousRecords {
+        &mut self.anonymous_records
+    }
+
+    pub fn named_records(&self) -> &OrderedHashMap<ValidatedNamedRecord> {
+        &self.named_records
+    }
+
+    pub(super) fn named_records_mut(&mut self) -> &mut OrderedHashMap<ValidatedNamedRecord> {
+        &mut self.named_records
+    }
+}
+
+impl From<String> for ValidatedTable {
+    fn from(s: String) -> Self {
+        Self {
+            name: s.into(),
+            named_records: OrderedHashMap::new(),
+            anonymous_records: ValidatedAnonymousRecords(Vec::new()),
+        }
+    }
+}
+
+impl Item for ValidatedTable {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A schema whose tables and records have all been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedSchema {
+    name: String,
+    tables: OrderedHashMap<ValidatedTable>,
+}
+
+impl ValidatedSchema {
+    pub(super) fn tables_mut(&mut self) -> &mut OrderedHashMap<ValidatedTable> {
+        &mut self.tables
+    }
+}
+
+impl From<String> for ValidatedSchema {
+    fn from(s: String) -> Self {
+        Self {
+            name: s.into(),
+            tables: OrderedHashMap::new(),
+        }
+    }
+}
+
+impl Item for ValidatedSchema {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A collection of schemas that have all been validated
+#[derive(Debug, PartialEq)]
+pub struct ValidatedSchemas(OrderedHashMap<ValidatedSchema>);
+
+impl ValidatedSchemas {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub(super) fn schemas_mut(&mut self) -> &mut OrderedHashMap<ValidatedSchema> {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
This PR adds the ability for one column to reference the value of another in a fully-qualified format, eg:

```
public
  employee
    bender
      likes_beer true
    fry
      likes_beer public.person@bender.likes_beer
```

Addresses https://github.com/kevlarr/hldr/issues/24

- [x] Update lexer
- [x] Update parser
- [x] Update validator
- [x] Update loader to use referenced values
- [x] Update README