### PR TITLE
New TOML options file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -33,9 +33,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -109,29 +109,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "generic-array",
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "fallible-iterator"
@@ -270,17 +266,17 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",
- "dotenv",
  "postgres",
+ "serde",
+ "toml",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
  "digest",
 ]
 
@@ -292,15 +288,6 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -317,10 +304,11 @@ checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -335,13 +323,11 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
 dependencies = [
- "block-buffer",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]
@@ -401,12 +387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "os_str_bytes"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,27 +397,25 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -478,9 +456,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "postgres"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb76d6535496f633fa799bb872ffb4790e9cbdedda9d35564ca0252f930c0dd5"
+checksum = "c8bbcd5f6deb39585a0d9f4ef34c4a41c25b7ad26d23c75d837d78c8e7adc85f"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -492,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b145e6a4ed52cb316a27787fc20fe8a25221cb476479f61e4e0327c15b98d91a"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
  "base64",
  "byteorder",
@@ -510,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
+checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
 dependencies = [
  "bytes",
  "chrono",
@@ -624,16 +602,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "sha2"
-version = "0.9.8"
+name = "serde"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
- "block-buffer",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]
@@ -745,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c8b33df661b548dcd8f9bf87debb8c56c05657ed291122e1188698c2ece95"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -768,16 +764,57 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -846,3 +883,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,18 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-dotenv = "0.15.0"
 postgres = "0.19.2"
+toml = "0.5.9"
 
 [dependencies.clap]
 version = "3.0.0-beta.5"
 default-features = false
 features = ["std", "cargo", "derive", "suggestions"]
 
+[dependencies.serde]
+version = "1"
+features = ["derive"]
+
 [dev-dependencies]
 chrono = "0.4.19"
-postgres = {version = "0.19.2", features = ["with-chrono-0_4"] }
+postgres = {version = "0.19.3", features = ["with-chrono-0_4"] }

--- a/README.md
+++ b/README.md
@@ -2,207 +2,306 @@
 
 *Simple, declarative data seeding for PostgreSQL*
 
-> See [Journey](https://github.com/kevlarr/jrny)
-> for a complementary, straightforward SQL-based database migration tool.
-
 **Important:** Placeholder is in quite the alpha state and still very feature-incomplete.
+
+---
 
 Placeholder strives to make generating _simple_ data much more succinct
 and cleaner than using SQL, PL/pgSQL, or even other programming languages
 with dedicated fixtures and factory libraries.
 
-With some powerful, easy to read syntax and a single `hldr` command,
+With some easy to read syntax and a single `hldr` command,
 you can have a well populated database in no time without setting up
 languages, dependencies, or verbose factory classes.
 
-See the corresponding [VS Code extension](https://github.com/kevlarr/vscode-hldr) for syntax highlighting examples.
+See the corresponding [VS Code extension](https://github.com/kevlarr/vscode-hldr)
+(also in an alpha state) for syntax highlighting examples.
 
-## Usage
+---
+
+## Contents
+
+1. [Installation](#installation)
+2. [Usage](#usage)
+   1. [Command-line options](#options)
+   2. [The options file](#the-options-file)
+3. [Features](#features)
+   1. [Literal values](#literal-values)
+   2. [Comments](#comments)
+   3. [Named records](#named-records)
+   4. [Table aliases](#table-aliases)
+
+---
+
+## Installation
 
 Placeholder currently must be compiled from source but precompiled
 binaries for common platforms should be [available soon](https://github.com/kevlarr/hldr/issues/16).
 
-Once compiled and installed to your path,
-to run the command you must specify the file to load and the
-database connection string.
+---
 
-These can be specified by the `-f [or --data-file]` and
-`-d [or --database-conn]` options.
+## Usage
 
-```
-# If installed in path as `hldr`
-$ hldr -f path/to/data/file -d postgres://user:password@host:port/db
-```
-
-### Default files
-
-There are several alternatives to using the command-line flags.
-
-If the data file is not specified, `hldr` will by default look for a data file named `place.hldr`
-in the current directory.
-
-Additionally, a `.placehldr` file (also in the current directory) can be used to specify either
-or both of the variables. For instance:
+Placeholder is designed to be easy to use.
+Run `hldr --help` or `hldr -h` to see usage and all available options.
 
 ```
-# For values with spaces, eg. the key-value connection string format, use double quotes.
-# database_conn="host=localhost dbname=my_database user=postgres"
-database_conn=postgres://postgres@localhost/my_database
+USAGE:
+    hldr [OPTIONS]
 
-# Specifying this means hldr will no longer look for the `place.hldr` default data file.
-# The .hldr extension is recommended but not necessary.
-data_file="my file.hldr"
+OPTIONS:
+    -c, --database-conn <CONN>     Database connection string, either key/value pair or URI style
+        --commit                   Commit the transaction
+    -f, --data-file <DATA-FILE>    Path to the .hldr data file to load [default: place.hldr if not
+                                   specified in options file]
+    -h, --help                     Print help information
+    -o, --opts-file <OPTS-FILE>    Path to the optional .toml options file [default: hldr-opts.toml]
+    -V, --version                  Print version information
 ```
 
-Any variable in the `.placehldr` file will be overridden in favor of any command-line options
-that are also supplied.
+### Options
 
-### Committing
+Ultimately, there are **3 things** to care about.
 
-By default, Placeholder will roll back the transaction,
-which is useful to test that all records can be created
-before finally applying them.
-If you want to commit the records, pass the `--commit` flag.
+#### 1. The data file to load
 
+By default, `hldr` will look for a file called `place.hldr` to load,
+but any other file can be loaded with the `--data-file <path>` or `-f <path>` option.
+
+```bash
+# Load the `place.hldr` file by default
+$ hldr
+
+# Or specify a different file
+$ hldr --data-file example.hldr
+$ hldr -f ../example.hldr
 ```
+
+#### 2. The database connection
+
+To specify database connection details, pass either key-value pair or
+URI-style string via `--database-conn` or `-c`.
+For available options, see the
+[postgres driver docs](https://docs.rs/postgres/latest/postgres/config/struct.Config.html).
+In general, options are similar to `libpq`.
+
+```bash
+# URI style
+$ hldr --database-conn "postgresql://user:password@host:port/dbname"
+$ hldr -c "postgresql://user:password@host:port/dbname"
+
+# Key/value style - useful when including `options` eg. to set custom search path
+$ hldr --database-conn "user=me password=passy options='-c search_path=schema1,schema2'"
+$ hldr -c "user=me password=passy options='-c search_path=schema1,schema2'"
+```
+
+#### 3. Whether the transaction should be committed or rolled back
+
+By default `hldr` rolls back the transaction to encourage dry-runs,
+so pass the `--commit` flag to override that behavior.
+
+```bash
+$ hldr
+Rolling back changes, pass `--commit` to apply
+
 $ hldr --commit
+Committing changes
 ```
+
+### The options file
+
+Specifying command-line options can be convenient (eg. when using
+environment variables on CI/CD) but can be especially tedious for
+local development.
+
+To make life easier, the database connection and default file can be
+specified in a `hldr-opts.toml` file.
+
+```toml
+# hldr-opts.toml
+#
+# None of these values are required, and if supplied they will be overridden
+# by any command-line options present
+
+data_file = "../some-custom-file.hldr"
+database_conn = "user=me password=passy options='-c search_path=schema1,schema2'"
+```
+
+If for whatever reason `hldr-opts.toml` is a disagreeable name,
+a custom options file can be specified.
+
+```bash
+$ hldr --opts-file ../path/to/file.toml
+$ hldr -o ../path/to/file.toml
+```
+
+**Important:** As this file can be environment-dependent and contain sensitive
+details, it **should not be checked into version control**.
+
+---
 
 ## Features
 
 Placeholder uses a clean, whitespace-significant syntax,
 with an indentation style of your choosing. Tabs or 3 spaces?
-Do whatever you want, as long as it's consistent.
+Do whatever you want, as long as it's consistent within the file.
+
+At a high level, a `.hldr` file with a single table and two records (one named, one anonymous) would essentially look like...
+
+```
+schema_name
+
+  table_name
+
+    record_name
+      column1 value1
+      column2 value2
+
+    _ 
+      column2 value3
+```
+
+... where records are grouped by table and tables are grouped by schema.
+
+Schema, table, and column names must match their names in the database,
+and they must be double-quoted if they contain non-standard
+characters like whitespace or punctuation.
+
+Unlike in Postgres, however, identifiers are not lowercased
+or truncated by default, so if you have Pascal- or camel-cased names, then you can just write them as-is.
+
+```
+schema
+
+  some_table
+
+    _
+      -- Whitespace in a schema, table, or column
+      -- name requires quoting
+      "the answer to everything" 41
+
+  -- But special casing DOES NOT
+  AnotherTable -- Instead of "AnotherTable"
+    ...
+```
+
+### Literal values
+
+Currently, there are only literal values for booleans, numbers, and text strings.
+Arrays, timestamps, or any other type that can be
+represented as text (and coerced by Postgres into the appropriate
+type) can be passed as a text string.
+
+#### Booleans
+
+Boolean values must be either `true` or `false`.
+Unlike SQL, values like `TRUE` or `f` are not supported.
+
+#### Numbers
+
+Literal values are supported for both integers and floats, eg. `123` or `12.34`.
+
+They are actually parsed (and passed) as text strings, so `hldr` does not
+attempt to distinguish the size of the integer or float; it leaves that
+up to Postgres to determine on a per-column basis.
+
+#### Text
+
+Text strings (whether `char`, `varchar`, or `text`) are all represented as single-quoted strings, eg. `'I am a text string'`.
+
+#### Other types
+
+Text strings can be used to represent any other type that has a
+text representation (timestamps, arrays, or even custom types) that
+Postgres can coerce to the appropriate type.
+
+For example, an array of integers would currently be written as `'{1, 2, 3}'`.
+
+### Comments
+
+Comments, like SQL, begin with `--` and can either be newline or trailing comments.
+
+```
+schema
+  -- A newline comment
+  table
+    record
+      column value -- A trailing comment
+```
+
+### Named records
 
 Records themselves can either be given a name, or they can be anonymous.
 Naming records allows their columns (even those populated by the database)
 to be referenced in other records.
 
-There are literal values for booleans, numbers, and text strings.
-
-- Numbers can be integers or floats; it will be up to the database to
-coerce them to the right type based on the column.
-
-- Text strings will also be coerced, which means they can be
-used to represent `varchar`, `text`, `timestamptz`, arrays like `int[]`, or any
-other type (even user-defined types) that can be constructed in SQL from string literals.
-
-The general file format looks like...
-
-```
-schema
-  table
-    record
-      column value
-```
-... where any number of schemas, tables, records, and attributes can be defined.
-
-For example, a simple file that looks like...
-
 ```
 public
   person
-    fry
-      name 'Philip J. Fry'
-      hair_color 'red'
+    -- A named record
+    kevin
+      name 'Kevin'
 
-    leela
-      name 'Turanga Leela'
-
-  pet
+    -- An anonymous record
     _
-      name 'Nibbler'
+      name 'A Different Kevin'
+
+  name
+    -- Record names only need to be unique within
+    -- the given table
+    kevin
+      value 'Kevin'
+      origin 'Irish'
 ```
 
-... will create three record (two named, one anonymous) like:
+### References
 
-```sql
-INSERT INTO "public"."person" ("name", "hair_color")
-  VALUES ('Philip J. Fry', 'red');
+Naming records allows them to be referenced elsewhere in the file,
+whether referencing a declared column *or* a column
+populated by default in the database.
 
-INSERT INTO "public"."person" ("name")
-  VALUES ('Turanga Leela');
+There are several supported reference formats:
 
-INSERT INTO "public"."pet" ("name")
-  VALUES ('Nibbler');
+| Format | Example | When Allowed |
+| --- | --: | --- |
+| Fully-qualified | `schema.table@record.column` | Always |
+| Table-qualified | `table@record.column` | When referencing a table in the same schema |
+| Unqualified | `@record.column` | When referencing a record in the same table |
+
+To demonstrate when the different formats are used:
+
 ```
+schema1
+  table1
+    record1
+      name 'Some record'
 
-Comments, like SQL, begin with `--` and can either be newline or trailing comments.
+    record2
+      -- Referencing record in same table can omit schema & table names
+      name @record1.name
 
-```
-public
-  -- This table has people in it
-  person
-    fry -- This is a named record
-      name 'Philip J. Fry'
+  table2
+    record1
+      -- Referencing record from another table in same schema
+      -- can omit the schema name
+      --
+      -- Note that `id` is not specified in the record declaration but
+      -- can still be referenced
+      table1_id table1@record1.id
 
-    -- This is an anonymous record...
+schema2
+  table1
     _
-      -- ... even though we know its name
-      name 'Morbo'
+      -- Must include schema and table when referencing a record from
+      -- a table in another schema
+      table2_id schema1.table2@record1.id
 ```
 
-Bare identifiers (ie. `public`, `person`, and `name` in the example above)
-are not lowercased or truncated automatically, like in SQL.
-Statements use quoted identifiers automatically,
-but (for the sake of the parser) you must explicitly quote identifiers
-that have whitespace, punctuation, etc.
+### Table aliases
 
-```
-"schema with whitespace"
-  "table.with -- dashes"
-    my_record
-      "column with spaces" 42
-```
-
-Records can also access values from other, named records using a fully-qualified
-format like `schema.table@record_name.column`.
-Columns do not need to be specified in the file to be referenced,
-such as columns with database defaults like primary keys.
-
-```
-public
-  person
-    fry
-      name 'Philip J. Fry'
-
-  pet
-    seymour
-      name 'Seymour Asses'
-      species 'Dog'
-      person_id public.person@fry.id
-```
-
-Additionally, if the referenced table is in the same schema,
-the schema name can be omitted.
-
-```
-public
-  person
-    fry
-      name 'Philip J. Fry'
-
-  pet
-    seymour
-      name 'Seymour Asses'
-      species 'Dog'
-      person_id person@fry.id
-```
-
-Likewise, if the referenced record is in the same table,
-the table name can be omitted as well.
-
-```
-public
-  bumblenum
-    humble
-      favorite_saying 'Yum yum!'
-
-    stumble
-      favorite_saying @humble.favorite_saying
-```
-
-Tables can also have aliases to help shorten qualified references.
+Tables can also have aliases to help shorten qualified references,
+and either the table name or alias can be used in any of the reference
+formats as desired.
 
 ```
 public
@@ -210,24 +309,18 @@ public
     p1
       name 'Person 1'
 
-    p2
-      name 'Person 2'
-
-    p3
-      name 'Person 3'
-
   pet
     _
-      -- Aliases can be schema-qualified
-      person_id public.p@fry.id
+      -- Fully-qualified reference using alias
+      person_id public.p@p1.id
 
     _
-      -- Or only be alias-qualified
-      person_id p@fry.id
+      -- Table-qualified reference using alias
+      person_id p@p1.id
 
     _
       -- And the original table name can still be used
-      person_id person@fry.id
+      person_id person@p1.id
 ```
 
 ## Planned features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,23 +10,16 @@ pub mod validate;
 
 pub use error::{HldrError, HldrErrorKind};
 
-#[derive(Clone, Debug, Default, Deserialize)]
-pub struct DatabaseConfig {
-    pub search_path: Option<String>,
+#[derive(Clone, Debug, Deserialize)]
+pub struct Settings {
+    #[serde(default = "default_data_file")]
+    pub file: PathBuf,
 
     #[serde(default)]
-    pub url: String,
+    pub database_conn: String,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct Config {
-    #[serde(default = "default_data_file")]
-    pub data_file: PathBuf,
-
-    pub database: DatabaseConfig,
-}
-
-impl Config {
+impl Settings {
     pub fn new(filepath: &str) -> Self {
         let path = PathBuf::from(filepath);
 
@@ -48,18 +41,13 @@ fn default_data_file() -> PathBuf {
     PathBuf::from("place.hldr")
 }
 
-pub fn place(config: &Config, commit: bool) -> Result<(), Box<dyn Error>> {
-    let content = fs::read_to_string(&config.data_file)?;
+pub fn place(settings: &Settings, commit: bool) -> Result<(), Box<dyn Error>> {
+    let content = fs::read_to_string(&settings.file)?;
     let tokens = lex::lex(&content)?;
     let schemas = parse::parse(tokens)?;
     let validated = validate::validate(schemas)?;
 
-    let mut client = load::new_client(&config.database.url)?;
-
-    if let Some(sp) = &config.database.search_path {
-        client.simple_query(&format!("SET search_path TO {}", sp))?;
-    }
-
+    let mut client = load::new_client(&settings.database_conn)?;
     let mut transaction = client.transaction()?;
 
     load::load(&mut transaction, &validated)?;
@@ -78,33 +66,15 @@ pub fn place(config: &Config, commit: bool) -> Result<(), Box<dyn Error>> {
 mod root_tests {
     use std::env;
 
-    use super::{place, Config, DatabaseConfig, PathBuf};
+    use super::{place, Settings, PathBuf};
 
     #[test]
-    #[should_panic]
-    fn panics_without_search_path() {
-        let database_url = env::var("HLDR_TEST_DATABASE_URL").unwrap();
-        let config = Config {
-            data_file: PathBuf::from("test/fixtures/place.hldr".to_owned()),
-            database: DatabaseConfig {
-                search_path: None,
-                url: database_url.clone(),
-            }
+    fn it_works() {
+        let settings = Settings {
+            file: PathBuf::from("test/fixtures/place.hldr".to_owned()),
+            database_conn: env::var("HLDR_TEST_DATABASE_URL").unwrap().clone(),
         };
 
-        place(&config, false).unwrap();
-    }
-
-    #[test]
-    fn respects_search_path() {
-        let config = Config {
-            data_file: PathBuf::from("test/fixtures/place.hldr".to_owned()),
-            database: DatabaseConfig {
-                search_path: Some("schema1, schema2".to_owned()),
-                url: env::var("HLDR_TEST_DATABASE_URL").unwrap().clone(),
-            }
-        };
-
-        place(&config, false).unwrap();
+        place(&settings, false).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod validate;
 
 pub use error::{HldrError, HldrErrorKind};
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Default, Debug, Deserialize)]
 pub struct Options {
     #[serde(default = "default_data_file")]
     pub data_file: PathBuf,
@@ -20,18 +20,20 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn new(filepath: &PathBuf) -> Self {
+    pub fn new(filepath: &PathBuf) -> Result<Option<Self>, String> {
         if !filepath.exists() {
-            panic!("{} file is missing", filepath.display());
+            return Ok(None);
         }
 
         if !filepath.is_file() {
-            panic!("{} is not a file", filepath.display());
+            return Err(format!("{} is not a file", filepath.display()));
         }
 
-        let contents = fs::read_to_string(&filepath).unwrap();
+        let contents = fs::read_to_string(&filepath)
+            .map_err(|e| e.to_string())?;
 
-        toml::from_str(&contents).unwrap()
+        Ok(toml::from_str(&contents)
+            .map_err(|e| e.to_string())?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-use std::{error::Error, fs, path::Path};
+use std::{error::Error, fs, path::PathBuf};
+
+use serde::Deserialize;
 
 pub mod error;
 pub mod lex;
@@ -8,18 +10,59 @@ pub mod validate;
 
 pub use error::{HldrError, HldrErrorKind};
 
-pub fn place(connstr: &str, filepath: &Path, commit: bool) -> Result<(), Box<dyn Error>> {
-    let text = fs::read_to_string(&filepath)?;
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct DatabaseConfig {
+    pub search_path: Option<String>,
+
+    #[serde(default)]
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub commit: bool,
+    pub database: DatabaseConfig,
+
+    #[serde(default = "default_data_file")]
+    pub data_file: PathBuf,
+}
+
+impl Config {
+    pub fn new(filepath: &str) -> Self {
+        let path = PathBuf::from(filepath);
+
+        if !path.exists() {
+            panic!("{} file is missing", filepath);
+        }
+
+        if !path.is_file() {
+            panic!("{} is not a file", filepath);
+        }
+
+        let contents = fs::read_to_string(&path).unwrap();
+
+        toml::from_str(&contents).unwrap()
+    }
+}
+
+fn default_data_file() -> PathBuf {
+    PathBuf::from("place.hldr")
+}
+
+
+pub fn place(config: &Config) -> Result<(), Box<dyn Error>> {
+    let text = fs::read_to_string(&config.data_file)?;
     let tokens = lex::lex(&text)?;
     let schemas = parse::parse(tokens)?;
     let validated = validate::validate(schemas)?;
 
-    let mut client = load::new_client(connstr)?;
+    let mut client = load::new_client(&config.database.url)?;
     let mut transaction = client.transaction()?;
 
     load::load(&mut transaction, &validated)?;
 
-    if commit {
+    if config.commit {
         println!("Committing changes");
         transaction.commit()?;
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,9 @@ struct Command {
 fn main() {
     let cmd = Command::parse();
     let options = {
-        let mut options = hldr::Options::new(&cmd.opts_file);
+        let mut options = hldr::Options::new(&cmd.opts_file)
+            .unwrap() // consume result
+            .unwrap_or_else(|| hldr::Options::default());
 
         // The options file can specify the data file and connection string,
         // which should be overridden by command-line options

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,8 @@ fn main() {
             config.database.search_path = Some(sp.clone());
         }
 
-        config.commit = cmd.commit;
         config
     };
 
-    hldr::place(&config).unwrap();
+    hldr::place(&config, cmd.commit).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use clap::{crate_version, Parser};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,37 +11,29 @@ struct Command {
     commit: bool,
 
     /// Path to the data file to load
-    #[clap(short = 'f', long = "data-file", name = "FILE")]
-    data_file: Option<PathBuf>,
+    #[clap(short = 'f', long = "file", name = "FILE")]
+    file: Option<PathBuf>,
 
     /// Database connection string - for allowed formats see: https://docs.rs/postgres/0.19.2/postgres/config/struct.Config.html
-    #[clap(short = 'd', long = "database-url", name = "URL")]
-    database_url: Option<String>,
-
-    /// Search path if overriding the default
-    #[clap(short = 's', long = "search-path", name = "PATH")]
-    search_path: Option<String>,
+    #[clap(short = 'c', long = "database-conn", name = "CONN")]
+    database_conn: Option<String>,
 }
 
 fn main() {
     let cmd = Command::parse();
-    let config = {
-        let mut config = hldr::Config::new("hldr.toml");
+    let settings = {
+        let mut settings = hldr::Settings::new("hldr.toml");
 
-        if let Some(df) = cmd.data_file {
-            config.data_file = df.clone();
+        if let Some(f) = cmd.file {
+            settings.file = f.clone();
         }
 
-        if let Some(url) = cmd.database_url {
-            config.database.url = url.clone();
+        if let Some(dc) = cmd.database_conn {
+            settings.database_conn = dc.clone();
         }
 
-        if let Some(sp) = cmd.search_path {
-            config.database.search_path = Some(sp.clone());
-        }
-
-        config
+        settings
     };
 
-    hldr::place(&config, cmd.commit).unwrap();
+    hldr::place(&settings, cmd.commit).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::{crate_version, Parser};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,5 +44,5 @@ fn main() {
         config
     };
 
-    hldr::place(&config);
+    hldr::place(&config).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,34 +6,40 @@ use clap::{crate_version, Parser};
 #[derive(Parser, Debug)]
 #[clap(version = crate_version!())]
 struct Command {
-    /// Commit the transaction, rolled back by default
+    /// Commit the transaction
     #[clap(long = "commit")]
     commit: bool,
 
-    /// Path to the data file to load
-    #[clap(short = 'f', long = "file", name = "FILE")]
+    /// Path to the .hldr data file to load [default: place.hldr if not specified in options file]
+    #[clap(short = 'f', long = "data-file", name = "DATA-FILE")]
     file: Option<PathBuf>,
 
-    /// Database connection string - for allowed formats see: https://docs.rs/postgres/0.19.2/postgres/config/struct.Config.html
+    /// Path to the optional .toml options file
+    #[clap(short = 'o', long = "opts-file", name = "OPTS-FILE", default_value = "hldr-opts.toml")]
+    opts_file: PathBuf,
+
+    /// Database connection string, either key/value pair or URI style
     #[clap(short = 'c', long = "database-conn", name = "CONN")]
     database_conn: Option<String>,
 }
 
 fn main() {
     let cmd = Command::parse();
-    let settings = {
-        let mut settings = hldr::Settings::new("hldr.toml");
+    let options = {
+        let mut options = hldr::Options::new(&cmd.opts_file);
 
+        // The options file can specify the data file and connection string,
+        // which should be overridden by command-line options
         if let Some(f) = cmd.file {
-            settings.file = f.clone();
+            options.data_file = f.clone();
         }
 
         if let Some(dc) = cmd.database_conn {
-            settings.database_conn = dc.clone();
+            options.database_conn = dc.clone();
         }
 
-        settings
+        options
     };
 
-    hldr::place(&settings, cmd.commit).unwrap();
+    hldr::place(&options, cmd.commit).unwrap();
 }

--- a/test/fixtures/place.hldr
+++ b/test/fixtures/place.hldr
@@ -3,20 +3,20 @@ schema1
     _
       name 'anon'
 
-    kevin
-      name      'Kevin'
-      birthdate '1982-11-19'
+    p1
+      name      'person 1'
+      birthdate '1900-01-01'
 
-    stace
-      name 'Stacey!!'
+    p2
+      name 'person 2'
 
   pet
-    eiyre
-      name      'Eiyre'
-      person_id p@kevin.id
+    p1
+      name      'pet 1'
+      person_id p@p1.id
       species   'cat'
 
-    cupid
-      name      'Cupid'
-      person_id p@stace.id
-      species   @eiyre.species
+    _
+      name      'pet 2'
+      person_id p@p2.id
+      species   @p1.species

--- a/test/fixtures/place.hldr
+++ b/test/fixtures/place.hldr
@@ -1,0 +1,22 @@
+schema1
+  person as p
+    _
+      name 'anon'
+
+    kevin
+      name      'Kevin'
+      birthdate '1982-11-19'
+
+    stace
+      name 'Stacey!!'
+
+  pet
+    eiyre
+      name      'Eiyre'
+      person_id p@kevin.id
+      species   'cat'
+
+    cupid
+      name      'Cupid'
+      person_id p@stace.id
+      species   @eiyre.species

--- a/test/jrny.toml
+++ b/test/jrny.toml
@@ -1,0 +1,6 @@
+[revisions]
+directory = "revisions"
+
+[table]
+schema = "public"
+name = "jrny_revision"

--- a/test/revisions/001.1638581278.basic schemas.sql
+++ b/test/revisions/001.1638581278.basic schemas.sql
@@ -1,0 +1,35 @@
+-- Revision: basic schemas
+--
+-- Add description here
+
+begin;
+
+create schema schema1;
+create schema schema2;
+
+create type schema2.marital_status as enum ('single', 'married', 'unknown');
+
+set search_path to schema1, schema2;
+
+create function schema2.married() returns marital_status
+  as 'select ''single''::marital_status'
+  language sql;
+
+create table schema1.person (
+  id int primary key generated always as identity,
+  name text not null,
+  birthdate date,
+
+  -- Not qualifying schema for 'married' function here helps test
+  -- for subtle search_path bugs
+  relationship_status marital_status default married()
+);
+
+create table schema1.pet (
+  id int primary key generated always as identity,
+  person_id int not null references person (id),
+  name text not null,
+  species text
+);
+
+commit;


### PR DESCRIPTION
`dotenv` was being used in an unsupported (ie. deprecated) fashion when parsing the key-value pair `.placehldr` file, and simple key/value isn't great anyway, so this PR updates to support an optional TOML "options" file.